### PR TITLE
[FEAT] 공용 컴포넌트 (SectionHeader, Button, DialogBox, ToastMessage) 구현

### DIFF
--- a/src/assets/icon/chevron-right.svg
+++ b/src/assets/icon/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 2L11 8L5 14" stroke="#D6D6D6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/index.ts
+++ b/src/assets/icon/index.ts
@@ -4,3 +4,4 @@ export { default as FloatingIcon } from "./floating.svg?react";
 export { default as KakaoIcon } from "./Kakao.svg?react";
 export { default as PencilIcon } from "./pencil.svg?react";
 export { default as XIcon } from "./x.svg?react";
+export { default as ChevronRightIcon } from "./chevron-right.svg?react";

--- a/src/components/common/CapsuleButton.tsx
+++ b/src/components/common/CapsuleButton.tsx
@@ -1,0 +1,50 @@
+import { useNavigate } from "react-router";
+
+type CapsuleSize = "small" | "medium";
+
+interface CapsuleButtonProps {
+  text: string;
+  image: string; // 아이콘 이미지 경로
+  link?: string;
+  size: CapsuleSize;
+  onClick?: () => void;
+  className?: string;
+}
+
+export const CapsuleButton = ({
+  text,
+  image,
+  link,
+  size,
+  onClick,
+  className = "",
+}: CapsuleButtonProps) => {
+  const router = useNavigate();
+
+  const baseClass =
+    "inline-flex items-center justify-center rounded-[50px] border border-transparent transition-all duration-200 active:scale-[0.99] bg-neutral-900 text-white hover:bg-neutral-800";
+
+  const sizeClass: Record<CapsuleSize, string> = {
+    small:
+      "w-[141px] h-[57px] gap-[8px] text-[16px] font-semibold drop-shadow-[0_6px_20px_rgba(238,114,68,0.5)]",
+
+    medium:
+      "w-[212px] h-[57px] gap-[8px] text-[16px] font-semibold drop-shadow-[0_6px_20px_rgba(238,114,68,0.5)]",
+  };
+
+  const handleClick = () => {
+    if (link) router(link);
+    if (onClick) onClick();
+  };
+
+  return (
+    <button
+      type="button"
+      className={`${baseClass} ${sizeClass[size]} ${className}`}
+      onClick={handleClick}
+    >
+      <img src={image} alt="" className="h-6 w-6 object-contain" />
+      <span>{text}</span>
+    </button>
+  );
+};

--- a/src/components/common/CapsuleButton.tsx
+++ b/src/components/common/CapsuleButton.tsx
@@ -1,10 +1,11 @@
 import { useNavigate } from "react-router";
+import type { ComponentType, SVGProps } from "react";
 
 type CapsuleSize = "small" | "medium";
 
 interface CapsuleButtonProps {
   text: string;
-  image: string; // 아이콘 이미지 경로
+  image: ComponentType<SVGProps<SVGSVGElement>>;
   link?: string;
   size: CapsuleSize;
   onClick?: () => void;
@@ -13,7 +14,7 @@ interface CapsuleButtonProps {
 
 export const CapsuleButton = ({
   text,
-  image,
+  image: Icon,
   link,
   size,
   onClick,
@@ -21,15 +22,19 @@ export const CapsuleButton = ({
 }: CapsuleButtonProps) => {
   const router = useNavigate();
 
+  const borderGradient =
+    "linear-gradient(139.21deg, rgba(172, 157, 157, 0.215) 0%, rgba(255, 255, 255, 0.5) 103.3%)";
+
+  const backgroundColor = "var(--color-neutral-900)";
+
   const baseClass =
-    "inline-flex items-center justify-center rounded-[50px] border border-transparent transition-all duration-200 active:scale-[0.99] bg-neutral-900 text-white hover:bg-neutral-800";
+    "inline-flex items-center justify-center rounded-[3.125rem] border border-transparent text-white transition-all duration-200 active:scale-[0.98] hover:brightness-110";
 
   const sizeClass: Record<CapsuleSize, string> = {
     small:
-      "w-[141px] h-[57px] gap-[8px] text-[16px] font-semibold drop-shadow-[0_6px_20px_rgba(238,114,68,0.5)]",
-
+      "w-[8.8125rem] h-[3.5625rem] px-[1.75rem] py-[1rem] gap-[0.5rem] text-[1rem] font-semibold",
     medium:
-      "w-[212px] h-[57px] gap-[8px] text-[16px] font-semibold drop-shadow-[0_6px_20px_rgba(238,114,68,0.5)]",
+      "w-[13.25rem] h-[3.5625rem] px-[1.75rem] py-[1rem] gap-[0.5rem] text-[1rem] font-semibold",
   };
 
   const handleClick = () => {
@@ -42,9 +47,16 @@ export const CapsuleButton = ({
       type="button"
       className={`${baseClass} ${sizeClass[size]} ${className}`}
       onClick={handleClick}
+      style={{
+        background: `
+          linear-gradient(${backgroundColor}, ${backgroundColor}) padding-box,
+          ${borderGradient} border-box
+        `,
+        border: "1px solid transparent",
+      }}
     >
-      <img src={image} alt="" className="h-6 w-6 object-contain" />
-      <span>{text}</span>
+      <Icon className="h-[1.5rem] w-[1.5rem]" />
+      <span className="whitespace-nowrap">{text}</span>
     </button>
   );
 };

--- a/src/components/common/CapsuleButton.tsx
+++ b/src/components/common/CapsuleButton.tsx
@@ -28,13 +28,11 @@ export const CapsuleButton = ({
   const backgroundColor = "var(--color-neutral-900)";
 
   const baseClass =
-    "inline-flex items-center justify-center rounded-[3.125rem] border border-transparent text-white transition-all duration-200 active:scale-[0.98] hover:brightness-110";
+    "inline-flex items-center justify-center rounded-[3.125rem] border border-transparent text-white transition-all duration-200 active:scale-[0.98] hover:brightness-110 h-[3.5625rem] px-[1.75rem] py-[1rem] gap-[0.5rem] text-[1rem] font-semibold";
 
   const sizeClass: Record<CapsuleSize, string> = {
-    small:
-      "w-[8.8125rem] h-[3.5625rem] px-[1.75rem] py-[1rem] gap-[0.5rem] text-[1rem] font-semibold",
-    medium:
-      "w-[13.25rem] h-[3.5625rem] px-[1.75rem] py-[1rem] gap-[0.5rem] text-[1rem] font-semibold",
+    small: "w-[8.8125rem]",
+    medium: "w-[13.25rem]",
   };
 
   const handleClick = () => {

--- a/src/components/common/DialogBox.tsx
+++ b/src/components/common/DialogBox.tsx
@@ -1,3 +1,5 @@
+import { createPortal } from "react-dom";
+
 type TextAlign = "center" | "left";
 type ConfirmStyle = "filled" | "text";
 
@@ -28,12 +30,14 @@ export const DialogBox = ({
   align = "center",
   confirmButtonStyle = "filled",
 }: DialogBoxProps) => {
-  if (!isOpen) return null;
+  //  닫혀있거나, SSR 환경(document가 없는 경우)에서는 렌더링하지 않음
+  if (!isOpen || typeof document === "undefined") return null;
 
   const borderGradient =
     "linear-gradient(139.21deg, rgba(172, 157, 157, 0.215) 0%, rgba(255, 255, 255, 0.5) 120.67%)";
 
-  return (
+  // 렌더링할 JSX 내용을 변수 혹은 createPortal 내부에 직접 작성
+  const modalContent = (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[0.125rem]">
       <div className="absolute inset-0" onClick={onCancel} />
 
@@ -93,4 +97,7 @@ export const DialogBox = ({
       </div>
     </div>
   );
+
+  // createPortal을 사용하여 document.body에 렌더링
+  return createPortal(modalContent, document.body);
 };

--- a/src/components/common/DialogBox.tsx
+++ b/src/components/common/DialogBox.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+type TextAlign = "center" | "left";
+type ConfirmStyle = "filled" | "text";
+
+interface DialogBoxProps {
+  isOpen: boolean; // 모달 표시 여부
+  title: string;
+  description?: string;
+
+  // 버튼 관련
+  confirmText: string; // 확인 버튼 텍스트 (예: 계속 편집, 확인)
+  onConfirm: () => void; // 확인 버튼 클릭 함수
+
+  cancelText?: string; // 취소 버튼 텍스트 (없으면 버튼 안 보임. 예: 저장 안 함)
+  onCancel?: () => void; // 취소 버튼 클릭 함수 (배경 클릭 시에도 호출됨)
+
+  // 스타일 옵션
+  align?: TextAlign;
+  confirmButtonStyle?: ConfirmStyle;
+}
+
+export const DialogBox = ({
+  isOpen,
+  title,
+  description,
+  confirmText,
+  onConfirm,
+  cancelText,
+  onCancel,
+  align = "center",
+  confirmButtonStyle = "filled",
+}: DialogBoxProps) => {
+  if (!isOpen) return null;
+
+  const borderGradient =
+    "linear-gradient(139.21deg, rgba(172, 157, 157, 0.215) 0%, rgba(255, 255, 255, 0.5) 120.67%)";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[0.125rem]">
+      <div className="absolute inset-0" onClick={onCancel} />
+
+      <div className="relative w-[20rem] rounded-[1.25rem] border border-[#3D3D3D] bg-[#1C1C1C] px-6 py-8">
+        <div
+          className={`mb-8 flex flex-col gap-2 ${align === "center" ? "text-center" : "text-left"}`}
+        >
+          <h2 className="text-[1.0625rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-line text-[#F0F0F0]">
+            {title}
+          </h2>
+          {description && (
+            <p className="font-regular text-[0.875rem] leading-[155%] tracking-[-0.02em] whitespace-pre-line text-[#D6D6D6]">
+              {description}
+            </p>
+          )}
+        </div>
+
+        <div
+          className={`flex items-center gap-3 ${align === "center" ? "justify-center" : "justify-end"}`}
+        >
+          {/* 취소 버튼 */}
+          {cancelText && (
+            <button
+              onClick={onCancel}
+              className="h-[3rem] flex-1 rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-[#D6D6D6] transition-all hover:brightness-110 active:scale-[0.98]"
+              style={{
+                background: `linear-gradient(#1C1C1C, #1C1C1C) padding-box, ${borderGradient} border-box`,
+                border: "1px solid transparent",
+              }}
+            >
+              {cancelText}
+            </button>
+          )}
+
+          {/* 확인 버튼 */}
+          {confirmButtonStyle === "filled" ? (
+            <button
+              onClick={onConfirm}
+              className={`${cancelText ? "flex-1" : "w-full"} h-[3rem] rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-[#F0F0F0] transition-all hover:brightness-110 active:scale-[0.98]`}
+              style={{
+                background: `linear-gradient(#E94E16, #E94E16) padding-box, ${borderGradient} border-box`,
+                border: "1px solid transparent",
+              }}
+            >
+              {confirmText}
+            </button>
+          ) : (
+            // 텍스트형 버튼
+            <button
+              onClick={onConfirm}
+              className="font-regular px-2 py-1 text-[0.875rem] leading-[155%] text-[#E94E16] transition-colors"
+            >
+              {confirmText}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/DialogBox.tsx
+++ b/src/components/common/DialogBox.tsx
@@ -4,17 +4,13 @@ type TextAlign = "center" | "left";
 type ConfirmStyle = "filled" | "text";
 
 interface DialogBoxProps {
-  isOpen: boolean; // 모달 표시 여부
+  isOpen: boolean;
   title: string;
   description?: string;
-
-  confirmText: string; // 확인 버튼 텍스트 (예: 계속 편집, 확인)
-  onConfirm: () => void; // 확인 버튼 클릭 함수
-
-  cancelText?: string; // 취소 버튼 텍스트 (없으면 버튼 안 보임. 예: 저장 안 함)
-  onCancel?: () => void; // 취소 버튼 클릭 함수 (배경 클릭 시에도 호출됨)
-
-  // 스타일 옵션
+  confirmText: string;
+  onConfirm: () => void;
+  cancelText?: string;
+  onCancel?: () => void;
   align?: TextAlign;
   confirmButtonStyle?: ConfirmStyle;
 }
@@ -30,18 +26,24 @@ export const DialogBox = ({
   align = "center",
   confirmButtonStyle = "filled",
 }: DialogBoxProps) => {
-  //  닫혀있거나, SSR 환경(document가 없는 경우)에서는 렌더링하지 않음
   if (!isOpen || typeof document === "undefined") return null;
 
   const borderGradient =
     "linear-gradient(139.21deg, rgba(172, 157, 157, 0.215) 0%, rgba(255, 255, 255, 0.5) 120.67%)";
 
-  // 렌더링할 JSX 내용을 변수 혹은 createPortal 내부에 직접 작성
   const modalContent = (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[0.125rem]">
-      <div className="absolute inset-0" onClick={onCancel} />
+    <div
+      // 1. 배경(Wrapper)에 직접 onClick 이벤트 할당
+      onClick={onCancel}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[0.125rem]"
+    >
+      {/* 기존의 absolute overlay div 제거됨 */}
 
-      <div className="bg-neutral-875/70 relative w-[20rem] rounded-[1.25rem] border border-neutral-800 px-6 py-8">
+      <div
+        // 2. 모달 내부 클릭 시 상위(배경)로 클릭 이벤트가 전파되지 않도록 차단
+        onClick={(e) => e.stopPropagation()}
+        className="bg-neutral-875/70 relative w-[20rem] rounded-[1.25rem] border border-neutral-800 px-6 py-8"
+      >
         <div
           className={`mb-8 flex flex-col gap-2 ${align === "center" ? "text-center" : "text-left"}`}
         >
@@ -58,7 +60,6 @@ export const DialogBox = ({
         <div
           className={`flex items-center gap-3 ${align === "center" ? "justify-center" : "justify-end"}`}
         >
-          {/* 취소 버튼 */}
           {cancelText && (
             <button
               onClick={onCancel}
@@ -72,7 +73,6 @@ export const DialogBox = ({
             </button>
           )}
 
-          {/* 확인 버튼 */}
           {confirmButtonStyle === "filled" ? (
             <button
               onClick={onConfirm}
@@ -85,7 +85,6 @@ export const DialogBox = ({
               {confirmText}
             </button>
           ) : (
-            // 텍스트형 버튼
             <button
               onClick={onConfirm}
               className="font-regular px-2 py-1 text-[0.875rem] leading-[155%] text-orange-500 transition-colors"
@@ -98,6 +97,5 @@ export const DialogBox = ({
     </div>
   );
 
-  // createPortal을 사용하여 document.body에 렌더링
   return createPortal(modalContent, document.body);
 };

--- a/src/components/common/DialogBox.tsx
+++ b/src/components/common/DialogBox.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type TextAlign = "center" | "left";
 type ConfirmStyle = "filled" | "text";
 
@@ -8,7 +6,6 @@ interface DialogBoxProps {
   title: string;
   description?: string;
 
-  // 버튼 관련
   confirmText: string; // 확인 버튼 텍스트 (예: 계속 편집, 확인)
   onConfirm: () => void; // 확인 버튼 클릭 함수
 
@@ -40,15 +37,15 @@ export const DialogBox = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[0.125rem]">
       <div className="absolute inset-0" onClick={onCancel} />
 
-      <div className="relative w-[20rem] rounded-[1.25rem] border border-[#3D3D3D] bg-[#1C1C1C] px-6 py-8">
+      <div className="bg-neutral-875/70 relative w-[20rem] rounded-[1.25rem] border border-neutral-800 px-6 py-8">
         <div
           className={`mb-8 flex flex-col gap-2 ${align === "center" ? "text-center" : "text-left"}`}
         >
-          <h2 className="text-[1.0625rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-line text-[#F0F0F0]">
+          <h2 className="text-[1.0625rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-line text-neutral-100">
             {title}
           </h2>
           {description && (
-            <p className="font-regular text-[0.875rem] leading-[155%] tracking-[-0.02em] whitespace-pre-line text-[#D6D6D6]">
+            <p className="font-regular text-[0.875rem] leading-[155%] tracking-[-0.02em] whitespace-pre-line text-neutral-200">
               {description}
             </p>
           )}
@@ -61,7 +58,7 @@ export const DialogBox = ({
           {cancelText && (
             <button
               onClick={onCancel}
-              className="h-[3rem] flex-1 rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-[#D6D6D6] transition-all hover:brightness-110 active:scale-[0.98]"
+              className="h-[3rem] flex-1 rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-200 transition-all hover:brightness-110 active:scale-[0.98]"
               style={{
                 background: `linear-gradient(#1C1C1C, #1C1C1C) padding-box, ${borderGradient} border-box`,
                 border: "1px solid transparent",
@@ -75,7 +72,7 @@ export const DialogBox = ({
           {confirmButtonStyle === "filled" ? (
             <button
               onClick={onConfirm}
-              className={`${cancelText ? "flex-1" : "w-full"} h-[3rem] rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-[#F0F0F0] transition-all hover:brightness-110 active:scale-[0.98]`}
+              className={`${cancelText ? "flex-1" : "w-full"} h-[3rem] rounded-[0.75rem] text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100 transition-all hover:brightness-110 active:scale-[0.98]`}
               style={{
                 background: `linear-gradient(#E94E16, #E94E16) padding-box, ${borderGradient} border-box`,
                 border: "1px solid transparent",
@@ -87,7 +84,7 @@ export const DialogBox = ({
             // 텍스트형 버튼
             <button
               onClick={onConfirm}
-              className="font-regular px-2 py-1 text-[0.875rem] leading-[155%] text-[#E94E16] transition-colors"
+              className="font-regular px-2 py-1 text-[0.875rem] leading-[155%] text-orange-500 transition-colors"
             >
               {confirmText}
             </button>

--- a/src/components/common/SectionHeader.tsx
+++ b/src/components/common/SectionHeader.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import { useNavigate } from "react-router";
 import { ChevronRightIcon } from "../../assets/icon";
 
 interface SectionHeaderProps {
-  title: string; // 예: "이번주 인기있는 현상소"
-  link?: string; // 이동할 경로 (예: "/places/popular") -> 없으면 더보기 버튼 숨김
+  title: string;
+  link?: string; // 이동할 경로
   onMoreClick?: () => void; // 링크 이동 외에 별도 기능이 필요할 때 대비
 }
 
@@ -26,7 +25,7 @@ export const SectionHeader = ({
   return (
     <div className="flex w-full items-center justify-between py-[1.25rem]">
       {/* 1. 왼쪽 타이틀 */}
-      <h2 className="text-[1.25rem] leading-[128%] font-semibold tracking-[-0.02em] text-[#F0F0F0]">
+      <h2 className="text-[1.25rem] leading-[128%] font-semibold tracking-[-0.02em] text-neutral-100">
         {title}
       </h2>
 
@@ -35,7 +34,7 @@ export const SectionHeader = ({
         <button
           onClick={handleMoreClick}
           type="button"
-          className="font-regular flex shrink-0 items-center gap-[0.125rem] text-[0.938rem] leading-[155%] tracking-[-0.02em] whitespace-nowrap text-[#D6D6D6]"
+          className="font-regular flex shrink-0 items-center gap-[0.125rem] text-[0.938rem] leading-[155%] tracking-[-0.02em] whitespace-nowrap text-neutral-200"
         >
           더보기
           <ChevronRightIcon className="h-[1rem] w-[1rem]" />

--- a/src/components/common/SectionHeader.tsx
+++ b/src/components/common/SectionHeader.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router";
-import { ChevronRightIcon } from "../../assets/icon";
+import { ChevronRightIcon } from "@/assets/icon";
 
 interface SectionHeaderProps {
   title: string;

--- a/src/components/common/SectionHeader.tsx
+++ b/src/components/common/SectionHeader.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { useNavigate } from "react-router";
+
+interface SectionHeaderProps {
+  title: string; // 예: "이번주 인기있는 현상소"
+  link?: string; // 이동할 경로 (예: "/places/popular") -> 없으면 더보기 버튼 숨김
+  onMoreClick?: () => void; // 링크 이동 외에 별도 기능이 필요할 때 대비
+}
+
+export const SectionHeader = ({
+  title,
+  link,
+  onMoreClick,
+}: SectionHeaderProps) => {
+  const navigate = useNavigate();
+
+  const handleMoreClick = () => {
+    if (onMoreClick) {
+      onMoreClick();
+    } else if (link) {
+      navigate(link);
+    }
+  };
+
+  return (
+    <div className="flex w-full items-center justify-between py-[1.25rem]">
+      {/* 1. 왼쪽 타이틀 */}
+      <h2 className="text-[1.25rem] leading-[128%] font-semibold tracking-[-0.02em] text-[#F0F0F0]">
+        {title}
+      </h2>
+
+      {/* 2. 오른쪽 더보기 버튼 (링크나 핸들러가 있을 때만 렌더링) */}
+      {(link || onMoreClick) && (
+        <button
+          onClick={handleMoreClick}
+          type="button"
+          className="font-regular flex items-center gap-[0.125rem] text-[0.938rem] leading-[155%] tracking-[-0.02em] text-[#D6D6D6]"
+        >
+          더보기
+          {/* Chevron Right Icon (화살표 >) */}
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-[1rem] w-[1rem]"
+          >
+            <path
+              d="M6 12L10 8L6 4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/common/SectionHeader.tsx
+++ b/src/components/common/SectionHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router";
+import { ChevronRightIcon } from "../../assets/icon";
 
 interface SectionHeaderProps {
   title: string; // 예: "이번주 인기있는 현상소"
@@ -34,26 +35,10 @@ export const SectionHeader = ({
         <button
           onClick={handleMoreClick}
           type="button"
-          className="font-regular flex items-center gap-[0.125rem] text-[0.938rem] leading-[155%] tracking-[-0.02em] text-[#D6D6D6]"
+          className="font-regular flex shrink-0 items-center gap-[0.125rem] text-[0.938rem] leading-[155%] tracking-[-0.02em] whitespace-nowrap text-[#D6D6D6]"
         >
           더보기
-          {/* Chevron Right Icon (화살표 >) */}
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-[1rem] w-[1rem]"
-          >
-            <path
-              d="M6 12L10 8L6 4"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <ChevronRightIcon className="h-[1rem] w-[1rem]" />
         </button>
       )}
     </div>

--- a/src/components/common/ToastMessage.tsx
+++ b/src/components/common/ToastMessage.tsx
@@ -8,7 +8,7 @@ interface ToastItemProps {
 
 export const ToastItem = ({ message, iconPath }: ToastItemProps) => {
   return (
-    <div className="animate-in fade-in slide-in-from-bottom-5 flex min-h-[3.75rem] w-[20.3125rem] items-center gap-[1rem] rounded-[1.125rem] border border-[#3D3D3D] bg-[#222222B2] px-[1.25rem] py-[1rem] shadow-lg duration-300">
+    <div className="animate-in fade-in slide-in-from-bottom-5 bg-neutral-875/70 flex min-h-[3.75rem] w-[20.3125rem] items-center gap-[1rem] rounded-[1.125rem] border border-neutral-800 px-[1.25rem] py-[1rem] shadow-lg duration-300">
       {/* 아이콘 영역 */}
       {iconPath && (
         <div className="flex h-[1.5rem] w-[1.5rem] flex-shrink-0 items-center justify-center">
@@ -21,7 +21,7 @@ export const ToastItem = ({ message, iconPath }: ToastItemProps) => {
       )}
 
       {/* 텍스트 영역 */}
-      <span className="text-[0.938rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-wrap text-[#D6D6D6]">
+      <span className="text-[0.938rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-wrap text-neutral-200">
         {message}
       </span>
     </div>

--- a/src/components/common/ToastMessage.tsx
+++ b/src/components/common/ToastMessage.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+// 개별 토스트 메시지 컴포넌트
+interface ToastItemProps {
+  message: string;
+  iconPath?: string;
+}
+
+export const ToastItem = ({ message, iconPath }: ToastItemProps) => {
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-5 flex min-h-[3.75rem] w-[20.3125rem] items-center gap-[1rem] rounded-[1.125rem] border border-[#3D3D3D] bg-[#222222B2] px-[1.25rem] py-[1rem] shadow-lg duration-300">
+      {/* 아이콘 영역 */}
+      {iconPath && (
+        <div className="flex h-[1.5rem] w-[1.5rem] flex-shrink-0 items-center justify-center">
+          <img
+            src={iconPath}
+            alt="icon"
+            className="h-full w-full object-contain"
+          />
+        </div>
+      )}
+
+      {/* 텍스트 영역 */}
+      <span className="text-[0.938rem] leading-[155%] font-semibold tracking-[-0.02em] whitespace-pre-wrap text-[#D6D6D6]">
+        {message}
+      </span>
+    </div>
+  );
+};
+
+// 토스트 컨테이너
+interface ToastListProps {
+  children: React.ReactNode;
+}
+
+export const ToastList = ({ children }: ToastListProps) => {
+  return (
+    <div className="fixed bottom-[2rem] left-1/2 z-[9999] flex -translate-x-1/2 flex-col gap-[0.75rem]">
+      {children}
+    </div>
+  );
+};

--- a/src/components/common/ToastMessage.tsx
+++ b/src/components/common/ToastMessage.tsx
@@ -3,20 +3,16 @@ import React from "react";
 // 개별 토스트 메시지 컴포넌트
 interface ToastItemProps {
   message: string;
-  iconPath?: string;
+  icon?: React.ReactNode;
 }
 
-export const ToastItem = ({ message, iconPath }: ToastItemProps) => {
+export const ToastItem = ({ message, icon }: ToastItemProps) => {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-5 bg-neutral-875/70 flex min-h-[3.75rem] w-[20.3125rem] items-center gap-[1rem] rounded-[1.125rem] border border-neutral-800 px-[1.25rem] py-[1rem] shadow-lg duration-300">
       {/* 아이콘 영역 */}
-      {iconPath && (
-        <div className="flex h-[1.5rem] w-[1.5rem] flex-shrink-0 items-center justify-center">
-          <img
-            src={iconPath}
-            alt="icon"
-            className="h-full w-full object-contain"
-          />
+      {icon && (
+        <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center text-neutral-400">
+          {icon}
         </div>
       )}
 


### PR DESCRIPTION
## 🔀 Pull Request Title
feat: 공용 UI 컴포넌트 4종 구현
- Closes #19

<br>

## 📌 PR 설명

디자인 시스템에 정의된 공용 UI 컴포넌트 구현을 진행했습니다. 

- [x] **ToastMessage**: 토스트 메시지 UI 및 등장 애니메이션 구현
- [x] **SectionHeader**: 페이지 섹션 헤더 구현 
- [x] **CapsuleButton**: 캡슐 버튼 구현 (Small/Medium 사이즈, 그라데이션 테두리 스타일 적용)
- [x] **DialogBox**: 다이얼로그 모달 구현 (기본형/알림형 분기, 좌측/중앙 정렬 옵션 추가)

<br>

## 📷 스크린샷

| 기능 | 스크린샷 |
| :--- | :--- |
| **DialogBox** | <img src="https://github.com/user-attachments/assets/1b806f4b-234a-402f-93bf-a5098966a785" width="300" /> <br> <img src="https://github.com/user-attachments/assets/4593d690-8353-4aae-a12a-6db5acee1d25" width="300" /> |
| **ToastMessage** | <img src="https://github.com/user-attachments/assets/2a0a9cbd-99b1-48d4-89f0-f74dce575a8e" width="300" /> |
| **CapsuleButton** <br> (Size/Icon) | <img src="https://github.com/user-attachments/assets/540ac0b2-9346-4851-aebc-1a9073659256" width="300" /> |
| **SectionHeader** | <img src="https://github.com/user-attachments/assets/5df0798f-2bac-4246-b45a-0d91ca0222a8" width="300" /> |
<br>