### PR TITLE
[FEAT] axiosInstance 생성

### DIFF
--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const baseURL = import.meta.env.VITE_PUBLIC_API_URL as string | undefined;
+
+if (!baseURL) {
+  // 런타임에서 바로 터뜨려서 env 누락을 초기에 잡게 함
+  throw new Error("VITE_PUBLIC_API_URL is not defined. Check your .env file.");
+}
+
+export const axiosInstance = axios.create({
+  baseURL,
+  timeout: 15000,
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -2,11 +2,6 @@ import axios from "axios";
 
 const baseURL = import.meta.env.VITE_PUBLIC_API_URL as string | undefined;
 
-if (!baseURL) {
-  // 런타임에서 바로 터뜨려서 env 누락을 초기에 잡게 함
-  throw new Error("VITE_PUBLIC_API_URL is not defined. Check your .env file.");
-}
-
 export const axiosInstance = axios.create({
   baseURL,
   timeout: 15000,

--- a/src/lib/setUpInterceptors.ts
+++ b/src/lib/setUpInterceptors.ts
@@ -1,0 +1,146 @@
+import { tokenStorage } from "@/utils/tokenStorage";
+import type {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+} from "axios";
+import axios from "axios";
+
+// 서버 스펙에 맞게 조정 가능
+type RefreshResponse = {
+  accessToken: string;
+  refreshToken?: string;
+};
+
+// 재시도 플래그를 config에 안전하게 심기 위한 타입 확장
+type RetryableConfig = InternalAxiosRequestConfig & { _retry?: boolean };
+
+// refresh 중복 호출 방지 + 대기열
+let isRefreshing = false;
+let pendingQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (err: unknown) => void;
+}> = [];
+
+function processQueue(error: unknown, newAccessToken: string | null) {
+  pendingQueue.forEach((p) => {
+    if (error) p.reject(error);
+    else if (newAccessToken) p.resolve(newAccessToken);
+    else p.reject(new Error("No new access token"));
+  });
+  pendingQueue = [];
+}
+
+function shouldSkipAuth(config: AxiosRequestConfig) {
+  // refresh 호출 자체는 Authorization 붙이면 꼬일 수 있어서 제외
+  const url = config.url ?? "";
+  return url.includes("/auth/refresh");
+}
+
+async function requestRefreshToken(baseURL: string) {
+  // refresh는 별도 axios로 호출(인터셉터 영향 X)
+  const refreshToken = tokenStorage.getRefreshToken();
+  if (!refreshToken) throw new Error("No refresh token");
+
+  // ✅ 너희 백엔드 스펙에 맞게 path/body만 바꾸면 됨
+  // 예) POST /auth/refresh { refreshToken }
+  const res = await axios.post<RefreshResponse>(
+    `${baseURL}/auth/refresh`,
+    { refreshToken },
+    { headers: { "Content-Type": "application/json" }, timeout: 15000 },
+  );
+
+  return res.data;
+}
+
+export function setupInterceptors(instance: AxiosInstance) {
+  // Request: accessToken 자동 첨부
+  instance.interceptors.request.use(
+    (config: InternalAxiosRequestConfig) => {
+      if (!shouldSkipAuth(config)) {
+        const accessToken = tokenStorage.getAccessToken();
+        if (accessToken) {
+          config.headers = config.headers ?? {};
+          config.headers.Authorization = `Bearer ${accessToken}`;
+        }
+      }
+      return config;
+    },
+    (error) => Promise.reject(error),
+  );
+
+  // Response: 401 -> refresh -> 원요청 재시도
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const status = error.response?.status;
+      const originalConfig = error.config as RetryableConfig | undefined;
+
+      if (!originalConfig) return Promise.reject(error);
+
+      // 401 아닌 경우 그냥 패스
+      if (status !== 401) return Promise.reject(error);
+
+      // refresh 요청이 401이면 더 이상 재시도하지 말고 로그아웃 처리
+      if (shouldSkipAuth(originalConfig)) {
+        tokenStorage.clear();
+        return Promise.reject(error);
+      }
+
+      // 무한 루프 방지
+      if (originalConfig._retry) {
+        tokenStorage.clear();
+        return Promise.reject(error);
+      }
+      originalConfig._retry = true;
+
+      const baseURL = instance.defaults.baseURL;
+      if (!baseURL) {
+        return Promise.reject(new Error("axiosInstance baseURL is not set"));
+      }
+
+      // 이미 refresh 중이면 큐에 대기
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          pendingQueue.push({
+            resolve: (newToken) => {
+              originalConfig.headers = originalConfig.headers ?? {};
+              originalConfig.headers.Authorization = `Bearer ${newToken}`;
+              resolve(instance(originalConfig));
+            },
+            reject,
+          });
+        });
+      }
+
+      // refresh 시작
+      isRefreshing = true;
+
+      try {
+        const data = await requestRefreshToken(baseURL);
+
+        // 토큰 저장
+        tokenStorage.setTokens({
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken ?? tokenStorage.getRefreshToken(),
+        });
+
+        // 대기 중인 요청들 처리
+        processQueue(null, data.accessToken);
+
+        // 원요청 재시도
+        originalConfig.headers = originalConfig.headers ?? {};
+        originalConfig.headers.Authorization = `Bearer ${data.accessToken}`;
+
+        return instance(originalConfig);
+      } catch (refreshErr) {
+        processQueue(refreshErr, null);
+        tokenStorage.clear();
+        return Promise.reject(refreshErr);
+      } finally {
+        isRefreshing = false;
+      }
+    },
+  );
+}

--- a/src/lib/setUpInterceptors.ts
+++ b/src/lib/setUpInterceptors.ts
@@ -42,7 +42,7 @@ async function requestRefreshToken(baseURL: string) {
   const refreshToken = tokenStorage.getRefreshToken();
   if (!refreshToken) throw new Error("No refresh token");
 
-  // 예) POST /auth/refresh { refreshToken }
+  // 예) POST /auth/reissue { refreshToken }
   const res = await axios.post<RefreshResponse>(
     `${baseURL}/auth/reissue`,
     { refreshToken },

--- a/src/lib/setUpInterceptors.ts
+++ b/src/lib/setUpInterceptors.ts
@@ -7,7 +7,6 @@ import type {
 } from "axios";
 import axios from "axios";
 
-// 서버 스펙에 맞게 조정 가능
 type RefreshResponse = {
   accessToken: string;
   refreshToken?: string;
@@ -43,10 +42,9 @@ async function requestRefreshToken(baseURL: string) {
   const refreshToken = tokenStorage.getRefreshToken();
   if (!refreshToken) throw new Error("No refresh token");
 
-  // ✅ 너희 백엔드 스펙에 맞게 path/body만 바꾸면 됨
   // 예) POST /auth/refresh { refreshToken }
   const res = await axios.post<RefreshResponse>(
-    `${baseURL}/auth/refresh`,
+    `${baseURL}/auth/reissue`,
     { refreshToken },
     { headers: { "Content-Type": "application/json" }, timeout: 15000 },
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,8 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
-import { setupInterceptors } from "./lib/setUpInterceptors.ts";
 import { axiosInstance } from "./lib/axiosInstance.ts";
+import { setupInterceptors } from "./lib/setUpInterceptors.ts";
 
 setupInterceptors(axiosInstance);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { setupInterceptors } from "./lib/setUpInterceptors.ts";
+import { axiosInstance } from "./lib/axiosInstance.ts";
+
+setupInterceptors(axiosInstance);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,0 +1,32 @@
+export type AuthTokens = {
+  accessToken: string | null;
+  refreshToken: string | null;
+};
+
+const ACCESS_KEY = "accessToken";
+const REFRESH_KEY = "refreshToken";
+
+export const tokenStorage = {
+  getAccessToken(): string | null {
+    return localStorage.getItem(ACCESS_KEY);
+  },
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(REFRESH_KEY);
+  },
+
+  setTokens(tokens: AuthTokens) {
+    if (tokens.accessToken)
+      localStorage.setItem(ACCESS_KEY, tokens.accessToken);
+    else localStorage.removeItem(ACCESS_KEY);
+
+    if (tokens.refreshToken)
+      localStorage.setItem(REFRESH_KEY, tokens.refreshToken);
+    else localStorage.removeItem(REFRESH_KEY);
+  },
+
+  clear() {
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+  },
+};


### PR DESCRIPTION
## 🔀 Pull Request Title

간결하고 명확한 제목 작성 (예: `feat: 로그인 기능 구현`)

- Closes #77 (이슈 번호가 있다면)

<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

### 주제1 <!-- 코드 첨부 -->
```
import { tokenStorage } from "@/utils/tokenStorage";
import type {
  AxiosError,
  AxiosInstance,
  AxiosRequestConfig,
  InternalAxiosRequestConfig,
} from "axios";
import axios from "axios";

type RefreshResponse = {
  accessToken: string;
  refreshToken?: string;
};

// 재시도 플래그를 config에 안전하게 심기 위한 타입 확장
type RetryableConfig = InternalAxiosRequestConfig & { _retry?: boolean };

// refresh 중복 호출 방지 + 대기열
let isRefreshing = false;
let pendingQueue: Array<{
  resolve: (token: string) => void;
  reject: (err: unknown) => void;
}> = [];

function processQueue(error: unknown, newAccessToken: string | null) {
  pendingQueue.forEach((p) => {
    if (error) p.reject(error);
    else if (newAccessToken) p.resolve(newAccessToken);
    else p.reject(new Error("No new access token"));
  });
  pendingQueue = [];
}

function shouldSkipAuth(config: AxiosRequestConfig) {
  // refresh 호출 자체는 Authorization 붙이면 꼬일 수 있어서 제외
  const url = config.url ?? "";
  return url.includes("/auth/refresh");
}

async function requestRefreshToken(baseURL: string) {
  // refresh는 별도 axios로 호출(인터셉터 영향 X)
  const refreshToken = tokenStorage.getRefreshToken();
  if (!refreshToken) throw new Error("No refresh token");

  // 예) POST /auth/refresh { refreshToken }
  const res = await axios.post<RefreshResponse>(
    `${baseURL}/auth/reissue`,
    { refreshToken },
    { headers: { "Content-Type": "application/json" }, timeout: 15000 },
  );

  return res.data;
}

export function setupInterceptors(instance: AxiosInstance) {
  // Request: accessToken 자동 첨부
  instance.interceptors.request.use(
    (config: InternalAxiosRequestConfig) => {
      if (!shouldSkipAuth(config)) {
        const accessToken = tokenStorage.getAccessToken();
        if (accessToken) {
          config.headers = config.headers ?? {};
          config.headers.Authorization = `Bearer ${accessToken}`;
        }
      }
      return config;
    },
    (error) => Promise.reject(error),
  );

  // Response: 401 -> refresh -> 원요청 재시도
  instance.interceptors.response.use(
    (response) => response,
    async (error: AxiosError) => {
      const status = error.response?.status;
      const originalConfig = error.config as RetryableConfig | undefined;

      if (!originalConfig) return Promise.reject(error);

      // 401 아닌 경우 그냥 패스
      if (status !== 401) return Promise.reject(error);

      // refresh 요청이 401이면 더 이상 재시도하지 말고 로그아웃 처리
      if (shouldSkipAuth(originalConfig)) {
        tokenStorage.clear();
        return Promise.reject(error);
      }

      // 무한 루프 방지
      if (originalConfig._retry) {
        tokenStorage.clear();
        return Promise.reject(error);
      }
      originalConfig._retry = true;

      const baseURL = instance.defaults.baseURL;
      if (!baseURL) {
        return Promise.reject(new Error("axiosInstance baseURL is not set"));
      }

      // 이미 refresh 중이면 큐에 대기
      if (isRefreshing) {
        return new Promise((resolve, reject) => {
          pendingQueue.push({
            resolve: (newToken) => {
              originalConfig.headers = originalConfig.headers ?? {};
              originalConfig.headers.Authorization = `Bearer ${newToken}`;
              resolve(instance(originalConfig));
            },
            reject,
          });
        });
      }

      // refresh 시작
      isRefreshing = true;

      try {
        const data = await requestRefreshToken(baseURL);

        // 토큰 저장
        tokenStorage.setTokens({
          accessToken: data.accessToken,
          refreshToken: data.refreshToken ?? tokenStorage.getRefreshToken(),
        });

        // 대기 중인 요청들 처리
        processQueue(null, data.accessToken);

        // 원요청 재시도
        originalConfig.headers = originalConfig.headers ?? {};
        originalConfig.headers.Authorization = `Bearer ${data.accessToken}`;

        return instance(originalConfig);
      } catch (refreshErr) {
        processQueue(refreshErr, null);
        tokenStorage.clear();
        return Promise.reject(refreshErr);
      } finally {
        isRefreshing = false;
      }
    },
  );
}
```
- 요청시 토큰 존재할 경우 토큰 첨부, 401 응답 시 토큰 재발급  

### 주제2

- <br>

## 📌 PR 설명
api 요청에 시에 사용할 axiosInstance와 interceptor를 구현했습니다. 
### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] axiosInstance.ts
- [x] setUpInterceptors.ts
- [x] tokenStorage.ts

<br>

## 📷 스크린샷

UI 변경이 있을 경우 스크린샷을 첨부해주세요.

<br>
