### PR TITLE
[DESIGN] PhotoLab 디자인 변경

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -51,3 +51,19 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome/Safari */
 }
+
+/* 스크롤 영역 오른쪽 fade-out, webkit은 부분 지원 브라우저를 위해 */
+.scroll-fade-right {
+  mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black calc(100% - 1rem),
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black calc(100% - 1rem),
+    transparent 100%
+  );
+}

--- a/src/App.css
+++ b/src/App.css
@@ -57,13 +57,13 @@
   mask-image: linear-gradient(
     to right,
     black 0%,
-    black calc(100% - 1rem),
+    black calc(100% - 1.5rem),
     transparent 100%
   );
   -webkit-mask-image: linear-gradient(
     to right,
     black 0%,
-    black calc(100% - 1rem),
+    black calc(100% - 1.5rem),
     transparent 100%
   );
 }

--- a/src/App.css
+++ b/src/App.css
@@ -54,16 +54,12 @@
 
 /* 스크롤 영역 오른쪽 fade-out, webkit은 부분 지원 브라우저를 위해 */
 .scroll-fade-right {
-  mask-image: linear-gradient(
+  --scroll-fade-gradient: linear-gradient(
     to right,
     black 0%,
     black calc(100% - 1.5rem),
     transparent 100%
   );
-  -webkit-mask-image: linear-gradient(
-    to right,
-    black 0%,
-    black calc(100% - 1.5rem),
-    transparent 100%
-  );
+  -webkit-mask-image: var(--scroll-fade-gradient);
+  mask-image: var(--scroll-fade-gradient);
 }

--- a/src/components/common/FilterContainer.tsx
+++ b/src/components/common/FilterContainer.tsx
@@ -25,7 +25,7 @@ export default function FilterContainer({
       <span className="text-[1rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100">
         {displayText}
       </span>
-      <Icon className="-rotate-90 text-neutral-200">
+      <Icon size="lg" className="-rotate-90 text-neutral-200">
         <ChevronLeftIcon />
       </Icon>
     </button>

--- a/src/components/photoLab/FilterTagList.tsx
+++ b/src/components/photoLab/FilterTagList.tsx
@@ -22,7 +22,7 @@ export default function FilterTagList({
 }: FilterTagListProps) {
   return (
     <div
-      className={`scrollbar-hide -mr-4 flex gap-2 overflow-x-auto pr-4 ${className}`}
+      className={`scrollbar-hide scroll-fade-right flex gap-2 overflow-x-auto ${className}`}
     >
       {FILTER_TAGS.map((tag) => (
         <FilterChip

--- a/src/components/photoLab/LabCard.tsx
+++ b/src/components/photoLab/LabCard.tsx
@@ -130,9 +130,9 @@ export default function LabCard({
           </div>
         </div>
 
-        {/* Images Section - 오른쪽 패딩 밖으로 확장해서 다음 이미지 살짝 보이게, 혹은 추후에 화면 끝까지 */}
+        {/* Images Section */}
         {lab.imageUrls.length > 0 && (
-          <div className="scrollbar-hide -mr-4 flex gap-2 overflow-x-auto pr-4">
+          <div className="scrollbar-hide scroll-fade-right flex gap-2 overflow-x-auto">
             {lab.imageUrls.map((url, index) => (
               <img
                 key={index}

--- a/src/components/photoLab/detail/LabWorkResultsSection.tsx
+++ b/src/components/photoLab/detail/LabWorkResultsSection.tsx
@@ -43,7 +43,7 @@ export default function LabWorkResultsSection({
       </div>
 
       {/* 이미지 masonry 스크롤 - CSS columns로 세로 스택 후 가로 스크롤, 일단 최선.. */}
-      <div className="scrollbar-hide -mr-4 h-[16rem] overflow-x-auto overflow-y-hidden pr-4">
+      <div className="scrollbar-hide scroll-fade-right h-[16rem] overflow-x-auto overflow-y-hidden">
         <div className="flex h-full flex-col flex-wrap content-start gap-3">
           {previewImageUrls.map((url, index) => (
             <img


### PR DESCRIPTION
## 🔀 Pull Request Title

PhotoLab 디자인 변경

- Closes #61 

<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

### Filter Container의 chevron크기 확장(lg 추가)
```
<Icon size="lg" className="-rotate-90 text-neutral-200">
    <ChevronLeftIcon />
</Icon>
```
### 스크롤 영역 fade-out CSS 추가
```
.scroll-fade-right {
  --scroll-fade-gradient: linear-gradient(
    to right,
    black 0%,
    black calc(100% - 1.5rem),
    transparent 100%
  );
  -webkit-mask-image: var(--scroll-fade-gradient);
  mask-image: var(--scroll-fade-gradient);
}
```

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] Filter Container의 chevron크기 키우기
- [x] 스크롤 가능 영역 fade-out CSS 추가
- [x] Photolab의 스크롤 가능 영역을 fade out 으로 변경

<br>

## 📷 스크린샷

<img width="393" height="847" alt="image" src="https://github.com/user-attachments/assets/35ceb894-a6bf-45a7-90c6-d70c406577ef" />

<br>
