### PR TITLE
[HOTFIX] bottomsheet z값 수정

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -36,7 +36,7 @@ export default function BottomSheet({
   initialSnap = "collapsed",
   sheetClassName,
   isBackDrop = true,
-  overlay = true,
+  overlay = false,
 }: BottomSheetProps) {
   const sheetRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/components/photoLab/FilterBottomSheet.tsx
+++ b/src/components/photoLab/FilterBottomSheet.tsx
@@ -164,7 +164,7 @@ export default function FilterBottomSheet({
       expandedVh={expandedVh}
       collapsedRatio={expandedVh / 100}
       initialSnap="expanded"
-      overlay
+      overlay={true}
     >
       <div className="flex h-full flex-col">
         {/* 탭 */}

--- a/src/components/photoLab/FilterBottomSheet.tsx
+++ b/src/components/photoLab/FilterBottomSheet.tsx
@@ -164,6 +164,7 @@ export default function FilterBottomSheet({
       expandedVh={expandedVh}
       collapsedRatio={expandedVh / 100}
       initialSnap="expanded"
+      overlay
     >
       <div className="flex h-full flex-col">
         {/* 탭 */}

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -343,6 +343,7 @@ export default function PhotoFeedSearchPage() {
         <BottomSheet
           open={bottomSheetOpen}
           collapsedRatio={0.44}
+          overlay
           onClose={() => {
             setBottomSheetOpen(false);
           }}

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -343,7 +343,7 @@ export default function PhotoFeedSearchPage() {
         <BottomSheet
           open={bottomSheetOpen}
           collapsedRatio={0.44}
-          overlay
+          overlay={true}
           onClose={() => {
             setBottomSheetOpen(false);
           }}


### PR DESCRIPTION
## 🔀 Pull Request Title

BottomSheet의 높이가 의도와 다르게 나오던 문제 해결

- Closes #145 

<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

### 기존 의도와 반대로 동작하던 BottomSheet의 기존 props 변경
```
export default function BottomSheet({
  open,
  onClose,
  title,
  children,
  collapsedRatio = 0.66,
  expandedVh = 92,
  initialSnap = "collapsed",
  sheetClassName,
  isBackDrop = true,
  overlay = false,
}: BottomSheetProps) {
```
- <br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] BottomSheet의 높이가 의도와 다르게 나오던 문제 해결

<br>

## 📷 스크린샷

<img width="418" height="877" alt="image" src="https://github.com/user-attachments/assets/12b343d8-aa94-4163-af54-1035f0fef41b" />
<img width="414" height="878" alt="image" src="https://github.com/user-attachments/assets/8714b5e8-50f8-4c87-b389-3c44da805ab1" />
<img width="413" height="879" alt="image" src="https://github.com/user-attachments/assets/9c63e1f2-7ebf-4483-bbe3-968dc14ef88f" />
<img width="409" height="875" alt="image" src="https://github.com/user-attachments/assets/b2ca78aa-1a04-4dd8-b417-96168574b42d" />


<br>
