### PR TITLE
[BUG] PL 페이지 거리 표시 수정

### DIFF
--- a/src/components/photoLab/LabCard.tsx
+++ b/src/components/photoLab/LabCard.tsx
@@ -87,9 +87,11 @@ export default function LabCard({
                 <span className="text-[0.875rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
                   {lab.address}
                 </span>
-                <span className="text-[0.875rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
-                  ({lab.distanceKm}km)
-                </span>
+                {lab.distanceKm != null && (
+                  <span className="text-[0.875rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
+                    ({lab.distanceKm.toFixed(1)}km)
+                  </span>
+                )}
               </div>
 
               {/* 작업 건수 + 소요시간 */}

--- a/src/components/photoLab/detail/LabBasicInfo.tsx
+++ b/src/components/photoLab/detail/LabBasicInfo.tsx
@@ -73,9 +73,11 @@ export default function LabBasicInfo({
               <span className="text-[0.9375rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
                 {lab.address}
               </span>
-              <span className="text-[0.9375rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
-                ({lab.distanceKm}km)
-              </span>
+              {lab.distanceKm != null && (
+                <span className="text-[0.9375rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200">
+                  ({lab.distanceKm.toFixed(1)}km)
+                </span>
+              )}
             </div>
 
             {/* 작업 건수 + 소요시간 */}

--- a/src/components/photoLab/detail/LabLocationSection.tsx
+++ b/src/components/photoLab/detail/LabLocationSection.tsx
@@ -135,9 +135,11 @@ export default function LabLocationSection({
               {fullAddress}
             </span>
           </button>
-          <p className="text-[0.875rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-300">
-            지금 내 위치에서 약 {distanceKm}km 거리에 있어요
-          </p>
+          {distanceKm != null && (
+            <p className="text-[0.875rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-300">
+              지금 내 위치에서 약 {distanceKm.toFixed(1)}km 거리에 있어요
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/types/photoLab.ts
+++ b/src/types/photoLab.ts
@@ -4,7 +4,7 @@ export interface PhotoLabItem {
   name: string;
   tags: string[];
   address: string;
-  distanceKm: number;
+  distanceKm: number | null;
   workCount: number;
   avgWorkTime: number;
   imageUrls: string[];


### PR DESCRIPTION
## 🔀 Pull Request Title

PL 페이지 거리 표시 수정

- Closes #109 

<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

### photoLab type에서 거리를 null로 받을 수 있도록 수정
```
export interface PhotoLabItem {
  photoLabId: number;
  name: string;
  tags: string[];
  address: string;
  distanceKm: number | null;
  workCount: number;
  avgWorkTime: number;
  imageUrls: string[];
  isFavorite: boolean;
}
```

### 거리가 null일 때 거리 텍스트를 렌더링하지 않도록 + 있으면 소수점 하나까지 나오도록 수정
```
{lab.distanceKm != null && (
    <span className="text-[0.9375rem] leading-[155%] font-normal tracking-[-0.02em] text-neutral-200"> 
        ({lab.distanceKm.toFixed(1)}km)
    </span>
)}
```
- <br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] null 거리 표시 방지
- [x] 거리 소수점 처리


<br>

## 📷 스크린샷

<img width="417" height="461" alt="image" src="https://github.com/user-attachments/assets/67e38c3d-cd8b-4698-a4cc-51d4f914d8dd" />
<img width="421" height="434" alt="image" src="https://github.com/user-attachments/assets/e3f5781b-10a0-4f38-97c1-9727daf929d0" />
<img width="419" height="329" alt="image" src="https://github.com/user-attachments/assets/8eb481ce-ea7f-4495-b8d3-2a81de4c4d55" />

<br>
