### PR TITLE
[REFACTOR] 사진수다 dto에 맞춰 타입 수정

### DIFF
--- a/src/apis/photoFeed/search.api.ts
+++ b/src/apis/photoFeed/search.api.ts
@@ -62,7 +62,7 @@ export async function getRecentSearches(): Promise<SearchHistory[]> {
  */
 export async function deleteRecentSearch(searchHistoryId: number) {
   const res = await axiosInstance.delete<ApiResponse<void>>(
-    `/search/history/${searchHistoryId}`,
+    `/posts/search/history/${searchHistoryId}`,
   );
 
   const body = res.data;

--- a/src/apis/photoFeed/search.api.ts
+++ b/src/apis/photoFeed/search.api.ts
@@ -60,9 +60,9 @@ export async function getRecentSearches(): Promise<SearchHistory[]> {
 /**
  * 사진수다 최근 검색어 개별 삭제
  */
-export async function deleteRecentSearch(historyId: number) {
+export async function deleteRecentSearch(searchHistoryId: number) {
   const res = await axiosInstance.delete<ApiResponse<void>>(
-    `/posts/search/history/${historyId}`,
+    `/search/history/${searchHistoryId}`,
   );
 
   const body = res.data;

--- a/src/hooks/photoFeed/search/useDeleteRecentSearch.ts
+++ b/src/hooks/photoFeed/search/useDeleteRecentSearch.ts
@@ -6,10 +6,11 @@ export function useDeleteRecentSearch() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (historyId: number) => deleteRecentSearch(historyId),
+    mutationFn: (searchHistoryId: number) =>
+      deleteRecentSearch(searchHistoryId),
 
     // 1. 요청 직전에 UI 먼저 변경
-    onMutate: async (historyId: number) => {
+    onMutate: async (searchHistoryId: number) => {
       // 진행 중인 refetch 중단 (덮어쓰기 방지)
       await queryClient.cancelQueries({
         queryKey: ["recentSearches"],
@@ -23,7 +24,8 @@ export function useDeleteRecentSearch() {
       // 캐시에서 해당 검색어 즉시 제거
       queryClient.setQueryData<SearchHistory[]>(
         ["recentSearches"],
-        (old) => old?.filter((item) => item.id !== historyId) ?? [],
+        (old) =>
+          old?.filter((item) => item.searchHistoryId !== searchHistoryId) ?? [],
       );
 
       // onError에서 쓸 컨텍스트 반환

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -199,8 +199,8 @@ export default function PhotoFeedSearchPage() {
           <div className="flex flex-col gap-4">
             {recentSearches.map((search) => (
               <SearchPost
-                key={search.id}
-                historyId={search.id}
+                key={search.searchHistoryId}
+                historyId={search.searchHistoryId}
                 image={search.imageUrl}
                 text={search.keyword}
                 onClick={() => handleSearch(search.keyword)}

--- a/src/types/mypage/post.ts
+++ b/src/types/mypage/post.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from "@/types/common/apiResponse";
+import type { PhotoFeedResponse } from "../photoFeed/postPreview";
 
 export type Post = {
   id: number;
@@ -8,25 +9,4 @@ export type Post = {
   likes: number;
 };
 
-export interface PostPreviewImageDto {
-  imageUrl: string;
-  width: number;
-  height: number;
-}
-
-export interface PostPreviewDto {
-  postId: number;
-  image: PostPreviewImageDto;
-  title: string;
-  likeCount: number;
-  commentCount: number;
-  isLiked: boolean;
-}
-
-export interface PostPreviewPageDto {
-  previewList: PostPreviewDto[];
-  totalCount: number;
-  isLast: boolean;
-}
-
-export type GetPostPreviewPageResponse = ApiResponse<PostPreviewPageDto>;
+export type GetPostPreviewPageResponse = ApiResponse<PhotoFeedResponse>;

--- a/src/types/photoFeed/postDetail.ts
+++ b/src/types/photoFeed/postDetail.ts
@@ -20,6 +20,7 @@ export type PostDetailResponse = {
 };
 
 type LabReview = {
+  postId: number;
   labId: number;
   labName: string;
   content: string;
@@ -56,6 +57,7 @@ export type LikesResponse = {
  */
 export type PostComment = {
   commentId: number;
+  postId: number;
   nickname: string;
   profileImageUrl: string;
   content: string;

--- a/src/types/photoFeed/postPreview.ts
+++ b/src/types/photoFeed/postPreview.ts
@@ -10,6 +10,7 @@ export type PostPreview = {
   likeCount: number;
   commentCount: number;
   isLiked: boolean;
+  createdAt: string;
 };
 
 export type PostImage = {
@@ -39,6 +40,7 @@ export const photoMock: PhotoFeedResponse = {
       likeCount: 0,
       commentCount: 0,
       isLiked: false,
+      createdAt: "",
     },
     {
       postId: 6,
@@ -52,6 +54,7 @@ export const photoMock: PhotoFeedResponse = {
       likeCount: 12,
       commentCount: 3,
       isLiked: true,
+      createdAt: "",
     },
     {
       postId: 5,
@@ -65,6 +68,7 @@ export const photoMock: PhotoFeedResponse = {
       likeCount: 4,
       commentCount: 1,
       isLiked: false,
+      createdAt: "",
     },
   ],
   totalCount: 5,

--- a/src/types/photoFeed/postSearch.ts
+++ b/src/types/photoFeed/postSearch.ts
@@ -13,10 +13,11 @@ export type SearchRequest = {
  * 최근 검색어 조회 응답 (CO-011)
  */
 export type SearchHistory = {
-  id: number;
+  searchHistoryId: number;
   keyword: string;
   imageUrl: string;
-  createdAt: string;
+  width: number;
+  height: number;
 };
 
 /**


### PR DESCRIPTION
## 🔀 Pull Request Title
사진수다 dto에 맞춰 타입 수정

- Closes #156 

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.
- 필드명 변경
- [x] 게시글 관련 응답: id -> postId
- [x] 검색 기록 목록: id -> searchHistoryId

- 응답 데이터 추가
- [x] 댓글: postId 추가
- [x] 좋아요/좋아요 취소: postId 추가
- [x] 현상소 리뷰: postId 추가

- Api 수정
- [x] 최근 검색어 개별 삭제: /posts/search/history/{historyId} -> /search/history/{searchHistoryId} (변수도 historyId -> searchHistoryId)

<br>

## 📷 스크린샷

UI 변경이 있을 경우 스크린샷을 첨부해주세요.

<br>
