### PR TITLE
[REFACTOR] 현상소 보기 1차 QA 반영

### DIFF
--- a/src/apis/photoLab/photoLab.api.ts
+++ b/src/apis/photoLab/photoLab.api.ts
@@ -16,6 +16,7 @@ function serializeListParams(params: PhotoLabListParams) {
     ...params,
     tagIds: params.tagIds?.join(","),
     regionIds: params.regionIds?.join(","),
+    time: params.time?.join(","),
   };
 }
 

--- a/src/apis/photoLab/photoLab.api.ts
+++ b/src/apis/photoLab/photoLab.api.ts
@@ -93,10 +93,9 @@ export async function getPopularPhotoLabs(): Promise<
 export async function getRegionFilters(): Promise<
   ApiResponse<RegionFilterData>
 > {
-  const res =
-    await axiosInstance.get<ApiResponse<RegionFilterData>>(
-      "/photo-labs/region",
-    );
+  const res = await axiosInstance.get<ApiResponse<RegionFilterData>>(
+    "/photo-labs/regions",
+  );
 
   const body = res.data;
 

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -74,6 +74,7 @@ export function TextArea({
       <textarea
         ref={textareaRef}
         value={value}
+        maxLength={maxLength}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}

--- a/src/components/mainPage/QuickMenuButton.tsx
+++ b/src/components/mainPage/QuickMenuButton.tsx
@@ -48,7 +48,9 @@ export default function QuickActionGrid() {
       <section className="mt-7.5 mb-7.5 grid h-51 grid-cols-2 grid-rows-2 gap-3 px-5">
         {/* 현상 맡기기 */}
         <ActionCard
-          onClick={() => requireAuthNavigate("/photolab")}
+          onClick={() =>
+            requireAuthNavigate("/photolab", { state: { from: "main" } })
+          }
           className="row-span-2 flex flex-col items-center justify-center gap-4 bg-linear-to-br from-[#2a2a2a] to-[#111111]"
         >
           <div className="flex size-12.5 items-center justify-center">

--- a/src/components/photoLab/FilterBottomSheet.tsx
+++ b/src/components/photoLab/FilterBottomSheet.tsx
@@ -117,28 +117,21 @@ export default function FilterBottomSheet({
 
   // RegionSelection[] → regionIds[] 변환
   const selectionsToRegionIds = (selections: RegionSelection[]): number[] => {
-    const ids: number[] = [];
-    for (const sel of selections) {
+    const ids = selections.flatMap((sel) => {
       if (sel.subRegion === "전체") {
-        // 해당 부모의 모든 자식 regionId 추가
-        if (regionData) {
-          const parent = regionData.parents.find(
-            (p) => p.parentName === sel.parentName,
-          );
-          if (parent) {
-            const childIds = regionData.regions
-              .filter((r) => r.parentId === parent.parentId)
-              .map((r) => r.regionId);
-            ids.push(...childIds);
-          }
-        }
-      } else {
-        const key = `${sel.parentName}-${sel.subRegion}`;
-        const id = regionIdMap.get(key);
-        if (id) ids.push(id);
+        if (!regionData) return [];
+        const parent = regionData.parents.find(
+          (p) => p.parentName === sel.parentName,
+        );
+        if (!parent) return [];
+        return regionData.regions
+          .filter((r) => r.parentId === parent.parentId)
+          .map((r) => r.regionId);
       }
-    }
-    // 중복 제거
+      const key = `${sel.parentName}-${sel.subRegion}`;
+      const id = regionIdMap.get(key);
+      return id ? [id] : [];
+    });
     return [...new Set(ids)];
   };
 

--- a/src/components/photoLab/FilterBottomSheet.tsx
+++ b/src/components/photoLab/FilterBottomSheet.tsx
@@ -69,8 +69,8 @@ export default function FilterBottomSheet({
     }
     return undefined;
   });
-  const [selectedTime, setSelectedTime] = useState<string | undefined>(
-    initialFilter?.time,
+  const [selectedTimes, setSelectedTimes] = useState<string[]>(
+    initialFilter?.time ?? [],
   );
   const [selectedRegion, setSelectedRegion] = useState<string | undefined>(
     initialFilter?.region,
@@ -84,10 +84,17 @@ export default function FilterBottomSheet({
     initialFilter?.region ?? defaultDisplayRegion,
   );
 
+  // 시간 토글 (복수 선택)
+  const handleTimeToggle = (time: string) => {
+    setSelectedTimes((prev) =>
+      prev.includes(time) ? prev.filter((t) => t !== time) : [...prev, time],
+    );
+  };
+
   // 초기화
   const handleReset = () => {
     setSelectedDate(undefined);
-    setSelectedTime(undefined);
+    setSelectedTimes([]);
     setSelectedRegion(undefined);
     setSelectedSubRegion(undefined);
     setDisplayedRegion(defaultDisplayRegion);
@@ -103,8 +110,8 @@ export default function FilterBottomSheet({
       const d = String(selectedDate.getDate()).padStart(2, "0");
       filter.date = `${y}-${m}-${d}`;
     }
-    if (selectedTime) {
-      filter.time = selectedTime;
+    if (selectedTimes.length > 0) {
+      filter.time = selectedTimes;
     }
     if (selectedRegion) {
       filter.region = selectedRegion;
@@ -197,8 +204,8 @@ export default function FilterBottomSheet({
               />
               <TimeSlotList
                 slots={TIME_SLOTS}
-                selectedTime={selectedTime}
-                onTimeSelect={setSelectedTime}
+                selectedTimes={selectedTimes}
+                onTimeToggle={handleTimeToggle}
               />
             </div>
           ) : (

--- a/src/components/photoLab/FilterBottomSheet.tsx
+++ b/src/components/photoLab/FilterBottomSheet.tsx
@@ -5,13 +5,12 @@ import Calendar from "./Calendar";
 import TimeSlotList from "./TimeSlotList";
 import RegionSelector from "./RegionSelector";
 import { TIME_SLOTS } from "@/constants/photoLab/timeSlots";
-import { REGIONS } from "@/constants/photoLab/regions";
+import { REGIONS, MAX_REGION_SELECTIONS } from "@/constants/photoLab/regions";
 import { useRegionFilters } from "@/hooks/photoLab";
 import type { FilterState, Region, RegionSelection } from "@/types/photoLab";
 
 // 컨텐츠에 필요한 최소 높이
 const CONTENT_MIN_HEIGHT_REM = 48;
-const MAX_REGION_SELECTIONS = 10;
 
 interface FilterBottomSheetProps {
   open: boolean;

--- a/src/components/photoLab/RegionSelector.tsx
+++ b/src/components/photoLab/RegionSelector.tsx
@@ -1,26 +1,38 @@
 import LocationChip from "@/components/common/chips/LocationChip";
-import type { Region } from "@/types/photoLab";
+import { XMarkIcon } from "@/assets/icon";
+import type { Region, RegionSelection } from "@/types/photoLab";
+
+const MAX_SELECTIONS = 10;
 
 interface RegionSelectorProps {
   regions: Region[];
-  selectedRegion?: string;
-  selectedSubRegion?: string;
-  displayedRegion: string; // 하위 지역 목록을 보여줄 광역 지역
-  onRegionSelect: (region: string) => void;
-  onSubRegionSelect: (subRegion: string) => void;
+  selectedRegions: RegionSelection[];
+  displayedRegion: string;
+  onRegionDisplay: (region: string) => void;
+  onSubRegionToggle: (parentName: string, subRegion: string) => void;
+  onRemoveSelection: (parentName: string, subRegion: string) => void;
 }
 
 export default function RegionSelector({
   regions,
-  selectedRegion,
-  selectedSubRegion,
+  selectedRegions,
   displayedRegion,
-  onRegionSelect,
-  onSubRegionSelect,
+  onRegionDisplay,
+  onSubRegionToggle,
+  onRemoveSelection,
 }: RegionSelectorProps) {
-  // 표시할 광역의 기초 자치단체 목록
   const currentRegion = regions.find((r) => r.name === displayedRegion);
   const subRegions = currentRegion?.subRegions ?? [];
+
+  // 해당 서브 리전이 선택되어 있는지 확인
+  const isSubRegionSelected = (subRegion: string) =>
+    selectedRegions.some(
+      (s) => s.parentName === displayedRegion && s.subRegion === subRegion,
+    );
+
+  // 해당 부모 지역에 선택된 항목이 있는지
+  const parentHasSelections = (parentName: string) =>
+    selectedRegions.some((s) => s.parentName === parentName);
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -38,8 +50,11 @@ export default function RegionSelector({
               key={region.name}
               label={region.name}
               count={region.count}
-              selected={selectedRegion === region.name}
-              onClick={() => onRegionSelect(region.name)}
+              selected={
+                displayedRegion === region.name ||
+                parentHasSelections(region.name)
+              }
+              onClick={() => onRegionDisplay(region.name)}
             />
           ))}
         </div>
@@ -47,27 +62,26 @@ export default function RegionSelector({
         {/* 오른쪽: 기초 자치단체 */}
         <div className="scrollbar-hide flex flex-1 flex-col overflow-y-auto">
           {subRegions.map((subRegion, index) => {
-            const isSelected = selectedSubRegion === subRegion;
-            const isNextSelected = selectedSubRegion === subRegions[index + 1];
+            const isSelected = isSubRegionSelected(subRegion);
             const isLastItem = index === subRegions.length - 1;
-            const hideBorder = isSelected || isNextSelected || isLastItem;
 
             return (
               <button
                 key={subRegion}
                 type="button"
-                onClick={() => onSubRegionSelect(subRegion)}
-                className={`flex items-center border-b px-4 py-2 text-left ${
-                  isSelected
-                    ? "bg-neutral-850 rounded-[0.625rem] border-transparent"
-                    : hideBorder
-                      ? "border-transparent"
-                      : "border-neutral-800"
-                }`}
+                onClick={() => onSubRegionToggle(displayedRegion, subRegion)}
+                disabled={
+                  !isSelected && selectedRegions.length >= MAX_SELECTIONS
+                }
+                className={`flex items-center px-4 py-2 text-left ${
+                  isLastItem ? "border-b-0" : "border-b border-neutral-800"
+                } disabled:opacity-40`}
               >
                 <span
-                  className={`text-[0.8125rem] leading-[155%] font-semibold tracking-[-0.02em] ${
-                    isSelected ? "text-orange-500" : "text-neutral-100"
+                  className={`text-[0.8125rem] leading-[155%] tracking-[-0.02em] ${
+                    isSelected
+                      ? "font-semibold text-orange-500"
+                      : "font-normal text-neutral-100"
                   }`}
                 >
                   {subRegion}
@@ -86,6 +100,41 @@ export default function RegionSelector({
           })}
         </div>
       </div>
+
+      {/* 선택된 지역 칩 영역 */}
+      {selectedRegions.length > 0 && (
+        <div className="flex flex-col gap-2 border-t border-neutral-800 pt-4">
+          <p className="text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100">
+            <span className="text-orange-500">최대 {MAX_SELECTIONS}개</span>
+            까지 선택할 수 있어요.
+          </p>
+
+          <div className="scrollbar-hide -mr-4 flex gap-[0.625rem] overflow-x-auto pr-4">
+            {selectedRegions.map((sel) => {
+              const chipLabel =
+                sel.subRegion === "전체"
+                  ? `${sel.parentName} 전체`
+                  : sel.subRegion;
+
+              return (
+                <button
+                  key={`${sel.parentName}-${sel.subRegion}`}
+                  type="button"
+                  onClick={() =>
+                    onRemoveSelection(sel.parentName, sel.subRegion)
+                  }
+                  className="bg-neutral-850 flex shrink-0 items-center gap-2 rounded-[0.75rem] px-3 py-[0.625rem]"
+                >
+                  <span className="text-[0.8125rem] leading-[155%] font-normal tracking-[-0.02em] text-white">
+                    {chipLabel}
+                  </span>
+                  <XMarkIcon className="h-4 w-4 text-neutral-400" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/photoLab/RegionSelector.tsx
+++ b/src/components/photoLab/RegionSelector.tsx
@@ -41,7 +41,7 @@ export default function RegionSelector({
       </h3>
 
       {/* 2열 레이아웃 */}
-      <div className="flex min-h-0 flex-1 gap-[3.75rem]">
+      <div className="flex min-h-0 flex-1 gap-[3.75rem] overflow-hidden">
         {/* 왼쪽: 광역 자치단체 */}
         <div className="scrollbar-hide flex w-[4.9375rem] flex-col gap-[0.625rem] overflow-y-auto">
           {regions.map((region) => (
@@ -102,7 +102,7 @@ export default function RegionSelector({
 
       {/* 선택된 지역 칩 영역 */}
       {selectedRegions.length > 0 && (
-        <div className="flex flex-col gap-2 border-t border-neutral-800 pt-4">
+        <div className="-mx-4 flex flex-col gap-2 border-t-2 border-neutral-800 px-4 pt-4">
           <p className="text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100">
             <span className="text-orange-500">
               최대 {MAX_REGION_SELECTIONS}개
@@ -129,7 +129,7 @@ export default function RegionSelector({
                   <span className="text-[0.8125rem] leading-[155%] font-normal tracking-[-0.02em] text-white">
                     {chipLabel}
                   </span>
-                  <XMarkIcon className="h-4 w-4 text-neutral-400" />
+                  <XMarkIcon className="h-3 w-3 text-neutral-200" />
                 </button>
               );
             })}

--- a/src/components/photoLab/RegionSelector.tsx
+++ b/src/components/photoLab/RegionSelector.tsx
@@ -1,8 +1,7 @@
 import LocationChip from "@/components/common/chips/LocationChip";
 import { XMarkIcon } from "@/assets/icon";
+import { MAX_REGION_SELECTIONS } from "@/constants/photoLab/regions";
 import type { Region, RegionSelection } from "@/types/photoLab";
-
-const MAX_SELECTIONS = 10;
 
 interface RegionSelectorProps {
   regions: Region[];
@@ -71,7 +70,7 @@ export default function RegionSelector({
                 type="button"
                 onClick={() => onSubRegionToggle(displayedRegion, subRegion)}
                 disabled={
-                  !isSelected && selectedRegions.length >= MAX_SELECTIONS
+                  !isSelected && selectedRegions.length >= MAX_REGION_SELECTIONS
                 }
                 className={`flex items-center px-4 py-2 text-left ${
                   isLastItem ? "border-b-0" : "border-b border-neutral-800"
@@ -105,7 +104,9 @@ export default function RegionSelector({
       {selectedRegions.length > 0 && (
         <div className="flex flex-col gap-2 border-t border-neutral-800 pt-4">
           <p className="text-[0.875rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100">
-            <span className="text-orange-500">최대 {MAX_SELECTIONS}개</span>
+            <span className="text-orange-500">
+              최대 {MAX_REGION_SELECTIONS}개
+            </span>
             까지 선택할 수 있어요.
           </p>
 

--- a/src/components/photoLab/TimeSlotList.tsx
+++ b/src/components/photoLab/TimeSlotList.tsx
@@ -2,14 +2,14 @@ import TimeFilterChip from "@/components/common/chips/TimeFilterChip";
 
 interface TimeSlotListProps {
   slots: string[];
-  selectedTime?: string;
-  onTimeSelect: (time: string) => void;
+  selectedTimes: string[];
+  onTimeToggle: (time: string) => void;
 }
 
 export default function TimeSlotList({
   slots,
-  selectedTime,
-  onTimeSelect,
+  selectedTimes,
+  onTimeToggle,
 }: TimeSlotListProps) {
   return (
     <div className="flex flex-col gap-3">
@@ -24,8 +24,8 @@ export default function TimeSlotList({
           <TimeFilterChip
             key={time}
             time={time}
-            selected={selectedTime === time}
-            onClick={() => onTimeSelect(time)}
+            selected={selectedTimes.includes(time)}
+            onClick={() => onTimeToggle(time)}
           />
         ))}
       </div>

--- a/src/components/photoLab/detail/LabBottomBar.tsx
+++ b/src/components/photoLab/detail/LabBottomBar.tsx
@@ -1,25 +1,16 @@
 interface LabBottomBarProps {
-  onInquiryClick?: () => void;
   onReservationClick?: () => void;
 }
 
 export default function LabBottomBar({
-  onInquiryClick,
   onReservationClick,
 }: LabBottomBarProps) {
   return (
     <div className="fixed right-0 bottom-0 left-0 z-10 flex justify-center border-t border-neutral-800 bg-neutral-900 px-4 py-5 pb-[calc(1.25rem+env(safe-area-inset-bottom,2.125rem))]">
       <button
         type="button"
-        onClick={onInquiryClick}
-        className="mr-3 flex h-16 w-[8.5rem] items-center justify-center rounded-2xl border border-neutral-700 bg-transparent text-[1.125rem] leading-[150%] font-semibold tracking-[-0.023em] text-neutral-200 active:scale-[0.99]"
-      >
-        문의
-      </button>
-      <button
-        type="button"
         onClick={onReservationClick}
-        className="flex h-16 w-[14rem] items-center justify-center rounded-2xl bg-orange-500 text-[1.125rem] leading-[150%] font-semibold tracking-[-0.023em] text-neutral-100 active:scale-[0.99]"
+        className="flex h-16 w-full items-center justify-center rounded-2xl bg-orange-500 text-[1.125rem] leading-[150%] font-semibold tracking-[-0.023em] text-neutral-100 active:scale-[0.99]"
       >
         예약하기
       </button>

--- a/src/constants/photoLab/regions.ts
+++ b/src/constants/photoLab/regions.ts
@@ -1,5 +1,8 @@
 import type { Region } from "@/types/photoLab";
 
+// 지역 최대 선택 개수
+export const MAX_REGION_SELECTIONS = 10;
+
 // 서울
 const SEOUL_AREAS = [
   "전체",

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { CTA_Button, SearchBar } from "@/components/common";
 import PhotoCard from "@/components/photoFeed/mainFeed/PhotoCard";
 import { ChevronLeftIcon, FloatingIcon } from "@/assets/icon";
@@ -40,13 +40,17 @@ const SKELETON_HEIGHTS = [
 
 export default function PhotoFeedSearchPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const initialLabName = location.state?.labName as string | undefined;
 
-  const [filter, setFilter] = useState<Filter>("TITLE");
+  const [filter, setFilter] = useState<Filter>(
+    initialLabName ? "LAB_NAME" : "TITLE",
+  );
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
 
-  const [inputText, setInputText] = useState(""); // 입력 중
-  const [searchText, setSearchText] = useState(""); // 제출된 검색어
+  const [inputText, setInputText] = useState(initialLabName ?? ""); // 입력 중
+  const [searchText, setSearchText] = useState(initialLabName ?? ""); // 제출된 검색어
   const [isSearching, setIsSearching] = useState(false); // input focus 상태
 
   const inputTrimmed = inputText.trim();

--- a/src/pages/photoLab/PhotoLabDetailPage.tsx
+++ b/src/pages/photoLab/PhotoLabDetailPage.tsx
@@ -74,7 +74,9 @@ export default function PhotoLabDetailPage() {
 
   return (
     <div className="flex w-full flex-col">
-      <Header title={lab.name} showBack onBack={handleBack} />
+      <div className="sticky top-0 z-20 -mx-4 bg-neutral-900 px-4">
+        <Header title={lab.name} showBack onBack={handleBack} />
+      </div>
 
       <main className="pb-32">
         {/* 메인 이미지 캐러셀 */}

--- a/src/pages/photoLab/PhotoLabDetailPage.tsx
+++ b/src/pages/photoLab/PhotoLabDetailPage.tsx
@@ -94,7 +94,11 @@ export default function PhotoLabDetailPage() {
         <LabWorkResultsSection
           labName={lab.name}
           postImageUrls={lab.postImageUrls}
-          onMoreClick={() => navigate("/photoFeed")}
+          onMoreClick={() =>
+            navigate("/photoFeed/search", {
+              state: { labName: lab.name },
+            })
+          }
         />
 
         {/* 지도 */}

--- a/src/pages/photoLab/PhotoLabPage.tsx
+++ b/src/pages/photoLab/PhotoLabPage.tsx
@@ -37,8 +37,8 @@ export default function PhotoLabPage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // 뒤로가기 버튼 표시 여부
-  const showBack = !!location.state?.from || window.history.length > 2;
+  // 메인 페이지 "현상 맡기기" 버튼을 통한 진입여부
+  const isFromMain = location.state?.from === "main";
 
   // TODO: FilterBottomSheet API 연동 (regionId, date 매핑)
   // 필터 상태
@@ -156,8 +156,8 @@ export default function PhotoLabPage() {
     <div className="flex w-full flex-col">
       {/* 헤더 */}
       <Header
-        title="현상 맡기기"
-        showBack={showBack}
+        title={isFromMain ? "현상 맡기기" : "현상소 보기"}
+        showBack={isFromMain}
         onBack={() => navigate(-1)}
         rightAction={{
           type: "icon",

--- a/src/pages/photoLab/PhotoLabPage.tsx
+++ b/src/pages/photoLab/PhotoLabPage.tsx
@@ -14,7 +14,7 @@ import {
   usePhotoLabList,
   useFavoriteToggle,
 } from "@/hooks/photoLab";
-import { displayTimeToApiTime } from "@/utils/time";
+import { displayTimesToApiTimes } from "@/utils/time";
 import type { LabNews, FilterState } from "@/types/photoLab";
 
 // TODO: Rolling 공지 API 엔드포인트 확정 후 연동
@@ -61,7 +61,10 @@ export default function PhotoLabPage() {
         parentRegionId: filter.parentRegionId,
         regionIds: filter.regionIds,
         date: filter.date,
-        time: filter.time ? displayTimeToApiTime(filter.time) : undefined,
+        time:
+          filter.time && filter.time.length > 0
+            ? displayTimesToApiTimes(filter.time)
+            : undefined,
         lat: latitude ?? undefined,
         lng: longitude ?? undefined,
       },

--- a/src/pages/photoLab/PhotoLabPage.tsx
+++ b/src/pages/photoLab/PhotoLabPage.tsx
@@ -58,7 +58,6 @@ export default function PhotoLabPage() {
     usePhotoLabList(
       {
         tagIds: selectedTagIds.length > 0 ? selectedTagIds : undefined,
-        parentRegionId: filter.parentRegionId,
         regionIds: filter.regionIds,
         date: filter.date,
         time:
@@ -89,11 +88,17 @@ export default function PhotoLabPage() {
       parts.push(`${month}.${day}(${weekday})`);
     }
 
-    if (filter.region) {
-      const regionText = filter.subRegion
-        ? `${filter.region} ${filter.subRegion}`
-        : filter.region;
-      parts.push(regionText);
+    if (filter.regionSelections && filter.regionSelections.length > 0) {
+      const first = filter.regionSelections[0];
+      const firstLabel =
+        first.subRegion === "전체"
+          ? `${first.parentName} 전체`
+          : `${first.parentName} ${first.subRegion}`;
+      if (filter.regionSelections.length === 1) {
+        parts.push(firstLabel);
+      } else {
+        parts.push(`${firstLabel} 외 ${filter.regionSelections.length - 1}개`);
+      }
     }
 
     return parts.length > 0 ? parts.join(" • ") : undefined;

--- a/src/pages/photoLab/PhotoLabPage.tsx
+++ b/src/pages/photoLab/PhotoLabPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { usePhotoLabFilter } from "@/store/usePhotoLabFilter.store";
 import { useNavigate, useLocation } from "react-router";
 import { Header, FilterContainer } from "@/components/common";
 import {
@@ -15,7 +16,8 @@ import {
   useFavoriteToggle,
 } from "@/hooks/photoLab";
 import { displayTimesToApiTimes } from "@/utils/time";
-import type { LabNews, FilterState } from "@/types/photoLab";
+import type { LabNews } from "@/types/photoLab";
+import type { FilterState } from "@/types/photoLab";
 
 // TODO: Rolling 공지 API 엔드포인트 확정 후 연동
 const mockNews: LabNews[] = [
@@ -40,11 +42,10 @@ export default function PhotoLabPage() {
   // 메인 페이지 "현상 맡기기" 버튼을 통한 진입여부
   const isFromMain = location.state?.from === "main";
 
-  // TODO: FilterBottomSheet API 연동 (regionId, date 매핑)
-  // 필터 상태
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+  // 필터 상태 (검색 페이지와 공유)
+  const { filter, setFilter, selectedTagIds, setSelectedTagIds } =
+    usePhotoLabFilter();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [filter, setFilter] = useState<FilterState>({});
 
   // 위치 정보
   const {
@@ -107,13 +108,16 @@ export default function PhotoLabPage() {
   const filterValue = formatFilterValue();
 
   // 태그 토글
-  const handleTagToggle = useCallback((tagId: number) => {
-    setSelectedTagIds((prev) =>
-      prev.includes(tagId)
-        ? prev.filter((id) => id !== tagId)
-        : [...prev, tagId],
-    );
-  }, []);
+  const handleTagToggle = useCallback(
+    (tagId: number) => {
+      setSelectedTagIds((prev) =>
+        prev.includes(tagId)
+          ? prev.filter((id) => id !== tagId)
+          : [...prev, tagId],
+      );
+    },
+    [setSelectedTagIds],
+  );
 
   // 즐겨찾기 토글
   const { mutate: toggleFavorite } = useFavoriteToggle();

--- a/src/pages/photoLab/PhotoLabPage.tsx
+++ b/src/pages/photoLab/PhotoLabPage.tsx
@@ -9,15 +9,14 @@ import {
   FilterBottomSheet,
 } from "@/components/photoLab";
 import { SearchIcon } from "@/assets/icon";
-import { WEEKDAYS } from "@/constants/date";
 import {
   useGeolocation,
   usePhotoLabList,
   useFavoriteToggle,
 } from "@/hooks/photoLab";
 import { displayTimesToApiTimes } from "@/utils/time";
-import type { LabNews } from "@/types/photoLab";
-import type { FilterState } from "@/types/photoLab";
+import { formatFilterValue } from "@/utils/filterFormat";
+import type { LabNews, FilterState } from "@/types/photoLab";
 
 // TODO: Rolling 공지 API 엔드포인트 확정 후 연동
 const mockNews: LabNews[] = [
@@ -77,35 +76,7 @@ export default function PhotoLabPage() {
     [data],
   );
 
-  // 필터 값 표시 문자열 계산
-  const formatFilterValue = (): string | undefined => {
-    const parts: string[] = [];
-
-    if (filter.date) {
-      const date = new Date(filter.date);
-      const month = date.getMonth() + 1;
-      const day = date.getDate();
-      const weekday = WEEKDAYS[date.getDay()];
-      parts.push(`${month}.${day}(${weekday})`);
-    }
-
-    if (filter.regionSelections && filter.regionSelections.length > 0) {
-      const first = filter.regionSelections[0];
-      const firstLabel =
-        first.subRegion === "전체"
-          ? `${first.parentName} 전체`
-          : `${first.parentName} ${first.subRegion}`;
-      if (filter.regionSelections.length === 1) {
-        parts.push(firstLabel);
-      } else {
-        parts.push(`${firstLabel} 외 ${filter.regionSelections.length - 1}개`);
-      }
-    }
-
-    return parts.length > 0 ? parts.join(" • ") : undefined;
-  };
-
-  const filterValue = formatFilterValue();
+  const filterValue = formatFilterValue(filter);
 
   // 태그 토글
   const handleTagToggle = useCallback(

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -22,7 +22,7 @@ import {
   useAutocomplete,
   useSearchPreview,
 } from "@/hooks/photoLab";
-import { displayTimeToApiTime } from "@/utils/time";
+import { displayTimesToApiTimes } from "@/utils/time";
 import { WEEKDAYS } from "@/constants/date";
 import { SEARCH_DEBOUNCE_MS } from "@/constants/photoLab";
 import type { FilterState } from "@/types/photoLab";
@@ -92,7 +92,10 @@ export default function PhotoLabSearchPage() {
         parentRegionId: filter.parentRegionId,
         regionIds: filter.regionIds,
         date: filter.date,
-        time: filter.time ? displayTimeToApiTime(filter.time) : undefined,
+        time:
+          filter.time && filter.time.length > 0
+            ? displayTimesToApiTimes(filter.time)
+            : undefined,
         lat: latitude ?? undefined,
         lng: longitude ?? undefined,
       },

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -23,7 +23,7 @@ import {
   useSearchPreview,
 } from "@/hooks/photoLab";
 import { displayTimesToApiTimes } from "@/utils/time";
-import { WEEKDAYS } from "@/constants/date";
+import { formatFilterValue } from "@/utils/filterFormat";
 import { SEARCH_DEBOUNCE_MS } from "@/constants/photoLab";
 import { usePhotoLabFilter } from "@/store/usePhotoLabFilter.store";
 
@@ -123,30 +123,7 @@ export default function PhotoLabSearchPage() {
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  // 필터 값 포맷
-  const formatFilterValue = (): string | undefined => {
-    const parts: string[] = [];
-    if (filter.date) {
-      const date = new Date(filter.date);
-      const month = date.getMonth() + 1;
-      const day = date.getDate();
-      const weekday = WEEKDAYS[date.getDay()];
-      parts.push(`${month}.${day}(${weekday})`);
-    }
-    if (filter.regionSelections && filter.regionSelections.length > 0) {
-      const first = filter.regionSelections[0];
-      const firstLabel =
-        first.subRegion === "전체"
-          ? `${first.parentName} 전체`
-          : `${first.parentName} ${first.subRegion}`;
-      if (filter.regionSelections.length === 1) {
-        parts.push(firstLabel);
-      } else {
-        parts.push(`${firstLabel} 외 ${filter.regionSelections.length - 1}개`);
-      }
-    }
-    return parts.length > 0 ? parts.join(" • ") : undefined;
-  };
+  const filterValue = formatFilterValue(filter);
 
   // 뒤로가기: 검색 결과 → 검색 입력, 검색 입력 → 현상소 목록
   const handleBack = () => {
@@ -255,7 +232,7 @@ export default function PhotoLabSearchPage() {
             <div className="flex flex-col gap-4 pb-6">
               <FilterContainer
                 label="날짜 / 지역"
-                value={formatFilterValue()}
+                value={filterValue}
                 onClick={() => setIsFilterOpen(true)}
               />
               <FilterTagList

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -148,9 +148,13 @@ export default function PhotoLabSearchPage() {
     return parts.length > 0 ? parts.join(" • ") : undefined;
   };
 
-  // 핸들러
+  // 뒤로가기: 검색 결과 → 검색 입력, 검색 입력 → 현상소 목록
   const handleBack = () => {
-    navigate(-1);
+    if (isResultsState) {
+      navigate("/photolab/search", { replace: true });
+    } else {
+      navigate("/photolab", { replace: true });
+    }
   };
 
   // 검색 제출 시 replace로 입력화면을 history에서 제거

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -25,7 +25,7 @@ import {
 import { displayTimesToApiTimes } from "@/utils/time";
 import { WEEKDAYS } from "@/constants/date";
 import { SEARCH_DEBOUNCE_MS } from "@/constants/photoLab";
-import type { FilterState } from "@/types/photoLab";
+import { usePhotoLabFilter } from "@/store/usePhotoLabFilter.store";
 
 export default function PhotoLabSearchPage() {
   const navigate = useNavigate();
@@ -64,10 +64,10 @@ export default function PhotoLabSearchPage() {
     useRecentSearches();
   const [isRecentExpanded, setIsRecentExpanded] = useState(false);
 
-  // 필터 상태 (results 화면용)
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+  // 필터 상태 (목록 페이지와 공유)
+  const { filter, setFilter, selectedTagIds, setSelectedTagIds } =
+    usePhotoLabFilter();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [filter, setFilter] = useState<FilterState>({});
 
   // 키워드 자동완성
   const { data: filteredKeywords = [] } = useAutocomplete(query);

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -89,7 +89,6 @@ export default function PhotoLabSearchPage() {
       {
         q: searchQuery || undefined,
         tagIds: selectedTagIds.length > 0 ? selectedTagIds : undefined,
-        parentRegionId: filter.parentRegionId,
         regionIds: filter.regionIds,
         date: filter.date,
         time:
@@ -134,11 +133,17 @@ export default function PhotoLabSearchPage() {
       const weekday = WEEKDAYS[date.getDay()];
       parts.push(`${month}.${day}(${weekday})`);
     }
-    if (filter.region) {
-      const regionText = filter.subRegion
-        ? `${filter.region} ${filter.subRegion}`
-        : filter.region;
-      parts.push(regionText);
+    if (filter.regionSelections && filter.regionSelections.length > 0) {
+      const first = filter.regionSelections[0];
+      const firstLabel =
+        first.subRegion === "전체"
+          ? `${first.parentName} 전체`
+          : `${first.parentName} ${first.subRegion}`;
+      if (filter.regionSelections.length === 1) {
+        parts.push(firstLabel);
+      } else {
+        parts.push(`${firstLabel} 외 ${filter.regionSelections.length - 1}개`);
+      }
     }
     return parts.length > 0 ? parts.join(" • ") : undefined;
   };

--- a/src/store/usePhotoLabFilter.store.ts
+++ b/src/store/usePhotoLabFilter.store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import type { FilterState } from "@/types/photoLab";
+
+type PhotoLabFilterState = {
+  filter: FilterState;
+  selectedTagIds: number[];
+
+  setFilter: (filter: FilterState) => void;
+  setSelectedTagIds: (
+    updater: number[] | ((prev: number[]) => number[]),
+  ) => void;
+  resetFilter: () => void;
+};
+
+export const usePhotoLabFilter = create<PhotoLabFilterState>()((set) => ({
+  filter: {},
+  selectedTagIds: [],
+
+  setFilter: (filter) => set({ filter }),
+  setSelectedTagIds: (updater) =>
+    set((state) => ({
+      selectedTagIds:
+        typeof updater === "function" ? updater(state.selectedTagIds) : updater,
+    })),
+  resetFilter: () => set({ filter: {}, selectedTagIds: [] }),
+}));

--- a/src/types/photoLab.ts
+++ b/src/types/photoLab.ts
@@ -83,14 +83,18 @@ export interface LabNews {
   content: string;
 }
 
+// 지역 선택 항목 (복수 선택용)
+export interface RegionSelection {
+  parentName: string; // "서울"
+  subRegion: string; // "전체" | "강남구" 등
+}
+
 // 필터 상태 (바텀시트용)
 export interface FilterState {
   date?: string; // "2026-01-15" 형식 (yyyy-MM-dd)
   time?: string[]; // ["오전 10:00", "오후 2:00"] 형식 (display용, 복수 선택)
-  region?: string; // "서울"
-  subRegion?: string; // "동작구"
-  parentRegionId?: number; // 상위(시/도) regionId
-  regionIds?: number[]; // 하위(구/군) regionId 배열
+  regionSelections?: RegionSelection[]; // 지역 선택 목록 (복수, 최대 10개)
+  regionIds?: number[]; // 하위(구/군) regionId 배열 (API용)
 }
 
 // GET /photo-labs/region 응답

--- a/src/types/photoLab.ts
+++ b/src/types/photoLab.ts
@@ -45,7 +45,7 @@ export interface PhotoLabListParams {
   parentRegionId?: number;
   regionIds?: number[];
   date?: string;
-  time?: string; // "HH:mm:ss" 형식
+  time?: string[]; // ["HH:mm:ss", ...] 형식, 복수 선택
   page?: number;
   size?: number;
   lat?: number;
@@ -86,7 +86,7 @@ export interface LabNews {
 // 필터 상태 (바텀시트용)
 export interface FilterState {
   date?: string; // "2026-01-15" 형식 (yyyy-MM-dd)
-  time?: string; // "오전 10:00" 형식 (display용)
+  time?: string[]; // ["오전 10:00", "오후 2:00"] 형식 (display용, 복수 선택)
   region?: string; // "서울"
   subRegion?: string; // "동작구"
   parentRegionId?: number; // 상위(시/도) regionId

--- a/src/types/photoLab.ts
+++ b/src/types/photoLab.ts
@@ -97,7 +97,7 @@ export interface FilterState {
   regionIds?: number[]; // 하위(구/군) regionId 배열 (API용)
 }
 
-// GET /photo-labs/region 응답
+// GET /photo-labs/regions 응답
 export interface RegionParent {
   parentId: number;
   parentName: string;

--- a/src/utils/filterFormat.ts
+++ b/src/utils/filterFormat.ts
@@ -1,0 +1,33 @@
+import { WEEKDAYS } from "@/constants/date";
+import type { FilterState } from "@/types/photoLab";
+
+/**
+ * FilterState를 FilterContainer에 표시할 문자열로 변환
+ * 예: "1.26(금) • 서울 강남구 외 2개"
+ */
+export function formatFilterValue(filter: FilterState): string | undefined {
+  const parts: string[] = [];
+
+  if (filter.date) {
+    const date = new Date(filter.date);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const weekday = WEEKDAYS[date.getDay()];
+    parts.push(`${month}.${day}(${weekday})`);
+  }
+
+  if (filter.regionSelections && filter.regionSelections.length > 0) {
+    const first = filter.regionSelections[0];
+    const firstLabel =
+      first.subRegion === "전체"
+        ? `${first.parentName} 전체`
+        : `${first.parentName} ${first.subRegion}`;
+    if (filter.regionSelections.length === 1) {
+      parts.push(firstLabel);
+    } else {
+      parts.push(`${firstLabel} 외 ${filter.regionSelections.length - 1}개`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" • ") : undefined;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -8,10 +8,18 @@ export function formatMMSS(totalSeconds: number) {
 
 /**
  * 필터 디스플레이 시간을 API 형식으로 변환
- * "오전 9:00" → "09:00:00"
- * "오후 2:00" → "14:00:00"
+ * "오전 9:00" → "09:00"
+ * "오후 2:00" → "14:00"
  */
 export function displayTimeToApiTime(displayTime: string): string {
   const bare = displayTime.replace(/^(오전|오후)\s*/, "");
-  return `${TIME_SLOT_TO_API[bare]}:00`;
+  return TIME_SLOT_TO_API[bare];
+}
+
+/**
+ * 디스플레이 시간 배열을 API 형식 배열로 변환
+ * ["오전 9:00", "오후 2:00"] → ["09:00", "14:00"]
+ */
+export function displayTimesToApiTimes(displayTimes: string[]): string[] {
+  return displayTimes.map(displayTimeToApiTime);
 }


### PR DESCRIPTION
## 🔀 Pull Request Title

현상소 보기 1차 QA 반영

- Closes #159 

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [ ] TC-PL-005 (특징태그 해당되는 현상소만 노출) **[DB 수정중]**
- [ ] TC-PL-013 (‘바텀시트’ > ‘날짜’ 탭에서 예약 불가 날짜) **[PM과 확인 필요]**
- [ ] TC-PL-015 (‘바텀시트’ > ‘날짜’ 탭에서 예약 불가 시간) **[PM과 확인 필요]**
- [ ] TC-PL-020 (‘지역’탭 옵션만 적용하고 [적용] 버튼) **[DB 수정중]**
- [ ] TC-PL-021 (‘날짜’, ‘지역’ 탭 옵션 모두 적용하고 [적용] 버튼 클릭 **[DB 수정중]**
- [x] TC-PL-002 (TabBar로 진입 시 뒤로가기 표시하지 않도록)
- [x] TC-PL-030 (탐색필터 조건들을 입력한 채로 → 검색할 때, 탐색필터 조건 유지된 채로 조건에 맞는 현상소 노출)
- [x] TC-PL-037 (PL-020 상하 스크롤 시 헤더, 하단 CTA 고정)
- [x] TC-PL-038 (PL-020 ‘작업결과물’ [>] 화살표 클릭 시 C co-013-1 화면의 검색창에는 탐색 중이던 현상소 이름 노출)
- [x] TC-PL-009-1 (0.0km로 소수점 둘째자리에서 반올림하여 노출한다. )
- [x] TC-PL-014 (클릭한 시간 버튼 오렌지색으로 변경. 복수 선택 가능)
- [x] TC-PL-017 (‘날짜’탭 옵션만 적용하고 [적용] 버튼)
- [x] TC-PL-019 (‘바텀시트’ > ‘지역별’ 탭 > 자치구 선택 시 복수 선택 가능)
- [x] TC-PL-022 (PL-011-1 ‘검색창’ [뒤로가기] 버튼 pl-010 화면으로 이동)
- [x] TC-PL-027 (검색어 입력 중일 때 입력한 키워드랑 일치, 부분일치하는 검색어 노출)
- [x] TC-PL-0311 (PL-011-3 ‘헤더’ 뒤로가기 클릭 시 pl-011-1로 이동)
- [x] TC-PL-0371 (위치 미동의 시 현 위치로부터의 거리가 노출되지 않음)
- [x] TC-PL-039 (‘위치’ [복사하기] 버튼 클릭 시, 클립보드에 주소 복사됨 + “클립보드에 주소가 복사되었어요” 토스트 메시지 노출)
- [x] TC-PL-0401 (현재 위치로 부터 0.0000km 떨어져 있는 경우, “지금 내 위치에서 약 0.0km 거리에 있어요.”라고 텍스트 노출)
- [x] TC-PL-0411 ([문의하기] 버튼 삭제)
- [x] TC-PL-049 (요청사항 작성 시, 글자수 유효성 검사)
- [x] TC-PL-0531 (PL-021-2. 현재 위치로 부터 0.0000km 떨어져 있는 경우 “지금 내 위치에서 약 0.0km 거리...")
- [x] TC-PL-054 (‘위치’ [복사하기] 버튼 클릭 시, 클립보드에 주소 복사됨 + 토스트 메시지 노출)
<br>

