### PR TITLE
[REFACTOR] 사진수다 QA 2차 반영

### DIFF
--- a/src/components/photoFeed/postDetail/PhotoCarousel.tsx
+++ b/src/components/photoFeed/postDetail/PhotoCarousel.tsx
@@ -1,38 +1,81 @@
 import { useCarousel } from "@/hooks/common/useCarousel";
 import type { PostImage } from "@/types/photoFeed/postPreview";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type Props = {
   images: PostImage[];
   altPrefix?: string;
 };
 
+const MIN_H = 11.25; // rem
+const MAX_H = 35; // rem
+const ROOT_FONT_SIZE = 16;
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
 export default function PhotoCarousel({ images, altPrefix = "photo" }: Props) {
   const { index, scrollerRef, scrollTo } = useCarousel(images.length);
 
+  // 캐러셀 폭(px)
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const [frameW, setFrameW] = useState(0);
+
+  useEffect(() => {
+    const el = frameRef.current;
+    if (!el) return;
+
+    const ro = new ResizeObserver(([entry]) => {
+      setFrameW(entry.contentRect.width); // px
+    });
+    ro.observe(el);
+
+    return () => ro.disconnect();
+  }, []);
+
+  // 첫 번째 사진 비율 → 높이(rem) 계산 + clamp
+  const fixedHRem = useMemo(() => {
+    const first = images[0];
+    if (!first || !frameW) return MIN_H;
+
+    const { width: w, height: h } = first;
+    if (!w || !h) return MIN_H;
+
+    // px → rem
+    const rawPx = frameW * (h / w);
+    const rawRem = rawPx / ROOT_FONT_SIZE;
+
+    return clamp(rawRem, MIN_H, MAX_H);
+  }, [images, frameW]);
+
   return (
     <div className="relative w-full overflow-hidden rounded-xl">
-      {/* 이미지 스크롤 영역 */}
-      <div
-        ref={scrollerRef}
-        className="flex w-full snap-x snap-mandatory overflow-x-auto scroll-smooth"
-        style={{
-          WebkitOverflowScrolling: "touch",
-          scrollbarWidth: "none",
-        }}
-      >
-        {images.map((img, i) => (
-          <div
-            key={`${img.imageUrl}-${i}`}
-            className="hide-scrollbar w-full flex-none snap-center"
-          >
-            <img
-              src={img.imageUrl}
-              alt={`${altPrefix}-${i + 1}`}
-              className="h-[361px] w-full object-cover"
-              draggable={false}
-            />
-          </div>
-        ))}
+      {/* 첫 사진 기준으로 높이 고정 (rem) */}
+      <div ref={frameRef} style={{ height: `${fixedHRem}rem` }}>
+        <div
+          ref={scrollerRef}
+          className="flex h-full w-full snap-x snap-mandatory overflow-x-auto scroll-smooth"
+          style={{
+            WebkitOverflowScrolling: "touch",
+            scrollbarWidth: "none",
+          }}
+        >
+          {images.map((img, i) => (
+            <div
+              key={`${img.imageUrl}-${i}`}
+              className="hide-scrollbar w-full flex-none snap-center"
+            >
+              {/* 모든 이미지는 동일한 높이를 사용 */}
+              <img
+                src={img.imageUrl}
+                alt={`${altPrefix}-${i + 1}`}
+                draggable={false}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* 점 인디케이터 */}

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -238,7 +238,7 @@ export default function PhotoFeedSearchPage() {
 
     if (relatedSearches && relatedSearches.length !== 0) {
       return (
-        <div className="flex flex-col gap-[1.875rem] pt-5">
+        <div className="flex flex-col gap-[1.875rem]">
           <KeywordSuggestionSection
             keywords={relatedSearches}
             onKeywordClick={handleSearch}
@@ -326,7 +326,7 @@ export default function PhotoFeedSearchPage() {
   return (
     <div className="relative min-h-dvh w-full flex-col">
       {/* SearchBar */}
-      <div className="py-3">
+      <div className="mb-5">
         <SearchBar {...searchBarProps} />
       </div>
 
@@ -336,7 +336,7 @@ export default function PhotoFeedSearchPage() {
       {mode === "result" && renderResult()}
 
       {/* 새 게시물 작성 플로팅 버튼 */}
-      {mode === "result" && (
+      {mode === "result" && !bottomSheetOpen && (
         <button
           type="button"
           aria-label="새 게시물 작성"

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -254,7 +254,7 @@ export default function PhotoFeedSearchPage() {
   const renderResult = () => {
     if (isSearchPending) {
       return (
-        <section className="mb-20 columns-2 gap-4 md:columns-3 xl:columns-4">
+        <section className="columns-2 gap-4 md:columns-3 xl:columns-4">
           {Array.from({ length: SKELETON_COUNT }).map((_, i) => {
             const heightClass = SKELETON_HEIGHTS[i % SKELETON_HEIGHTS.length];
 
@@ -298,7 +298,7 @@ export default function PhotoFeedSearchPage() {
               <ChevronLeftIcon className="h-4 w-4 rotate-[-90deg] text-neutral-200" />
             </button>
           </div>
-          <section className="mb-25 columns-2 gap-4 md:columns-3 xl:columns-4">
+          <section className="columns-2 gap-4 md:columns-3 xl:columns-4">
             {previewList.map((photo) => (
               <PhotoCard key={photo.postId} photo={photo} />
             ))}

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -326,7 +326,7 @@ export default function PhotoFeedSearchPage() {
   return (
     <div className="relative min-h-dvh w-full flex-col">
       {/* SearchBar */}
-      <div className="mb-5">
+      <div className="mt-3 mb-5">
         <SearchBar {...searchBarProps} />
       </div>
 


### PR DESCRIPTION
## 🔀 Pull Request Title
사진수다 QA 2차 반영

- Closes #187 

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] TC-CO-007 서치바와 관련 검색어 사이 여백 줄이기
- [x] TC-CO-012 검색 기준 바텀시트 표시할 때 플로팅 버튼 없애기
- [x] TC-CO-0491 게시글 뷰에서 사진 원본 비율로 출력
        - 최대한 원본 비율 반영 but 최대, 최소 높이 설정
        - 사진 여러 장인 경우 제일 앞 장의 높이에 맞추도록

<br>

- searchBar 아래 여백 제거 
<img width="572" height="1225" alt="image" src="https://github.com/user-attachments/assets/12d7514d-a3ff-4244-a407-53cf3a1b85ad" />

- 플로팅 버튼 에러 수정
<img width="579" height="1221" alt="image" src="https://github.com/user-attachments/assets/1b0e86ea-0d79-4170-8aba-74c5c0ae5d78" />

- 원본 비율 반영된 경우 
<img width="577" height="1059" alt="image" src="https://github.com/user-attachments/assets/af80a5a5-f001-4548-acfd-6a9b1630a901" />

- 가로로 긴 경우 -> 최소 높이 적용 
<img width="575" height="644" alt="image" src="https://github.com/user-attachments/assets/7fac627a-c6de-4dd7-a5a2-87cc0f727ec7" />

- 세로로 긴 경우 -> 최대 높이 적용 
<img width="578" height="1136" alt="image" src="https://github.com/user-attachments/assets/5a354f14-1936-4036-81d5-a01b684a8a98" />

<br>
