### PR TITLE
[REFACTOR] 메인페이지 3차 QA 반영

### DIFF
--- a/src/components/mainPage/Header.tsx
+++ b/src/components/mainPage/Header.tsx
@@ -1,15 +1,10 @@
-import { Link } from "react-router";
-
 export default function Header() {
   return (
     <header className="sticky top-0 z-50 flex h-14 w-full items-center justify-between bg-neutral-900">
       <div>
-        <Link
-          to="/"
-          className="font-ydestreet text-[1.625rem] leading-[132%] font-bold text-neutral-100"
-        >
+        <div className="font-ydestreet text-[1.625rem] leading-[132%] font-bold text-neutral-100">
           Finders
-        </Link>
+        </div>
       </div>
     </header>
   );

--- a/src/components/mainPage/NoticeSection/NoticeSection.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSection.tsx
@@ -1,9 +1,13 @@
+import { useRef } from "react";
 import NoticeSectionCard from "./NoticeSectionCard";
 import { SectionHeader } from "@/components/common/SectionHeader";
 import { usePhotoLabNotices } from "@/hooks/photoLab";
+import { useHorizontalScrollRestore } from "@/hooks/common";
 
 export default function NoticeSection() {
   const { data: notices, isLoading, isError } = usePhotoLabNotices();
+  const containerRef = useRef<HTMLDivElement>(null);
+  useHorizontalScrollRestore(containerRef, "notice_section");
 
   if (isLoading) return null;
   if (isError || !notices || notices.length === 0) return null;
@@ -14,15 +18,22 @@ export default function NoticeSection() {
       <SectionHeader title="현상소에서 알려드립니다" />
 
       {/* 가로 스크롤 리스트 */}
-      <div className="scrollbar-hide flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-20">
-        {notices.map((notice, index) => (
-          <div
-            key={`${notice.photoLabId}-${notice.noticeTitle}-${index}`}
-            className="flex-none snap-start"
-          >
-            <NoticeSectionCard notice={notice} />
-          </div>
-        ))}
+      <div
+        ref={containerRef}
+        className="scrollbar-hide relative flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-20"
+      >
+        {notices.map((notice, index) => {
+          const anchorId = `notice-${notice.photoLabId}-${index}`;
+          return (
+            <div
+              key={`${notice.photoLabId}-${notice.noticeTitle}-${index}`}
+              data-anchor-id={anchorId}
+              className="flex-none snap-start"
+            >
+              <NoticeSectionCard notice={notice} />
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/mainPage/NoticeSection/NoticeSection.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSection.tsx
@@ -26,7 +26,7 @@ export default function NoticeSection() {
           const anchorId = `notice-${notice.photoLabId}-${index}`;
           return (
             <div
-              key={`${notice.photoLabId}-${notice.noticeTitle}-${index}`}
+              key={anchorId}
               data-anchor-id={anchorId}
               className="flex-none snap-start"
             >

--- a/src/components/mainPage/NoticeSection/NoticeSectionCard.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSectionCard.tsx
@@ -34,7 +34,7 @@ export default function NoticeSectionCard({ notice }: NoticeSectionCardProps) {
         </h3>
       </div>
 
-      <div className="flex flex-col gap-[0.5] pt-3">
+      <div className="flex flex-col gap-0.5 pt-3">
         <div className="flex items-center gap-1.5">
           <NoticeLocationIcon className="h-3 w-3" />
           <span className="text-[0.75rem] leading-[126%] font-semibold tracking-[-0.02em] text-neutral-100">

--- a/src/components/mainPage/NoticeSection/NoticeSectionCard.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSectionCard.tsx
@@ -34,7 +34,7 @@ export default function NoticeSectionCard({ notice }: NoticeSectionCardProps) {
         </h3>
       </div>
 
-      <div className="flex flex-col gap-1.5 pt-3">
+      <div className="flex flex-col gap-[0.5] pt-3">
         <div className="flex items-center gap-1.5">
           <NoticeLocationIcon className="h-3 w-3" />
           <span className="text-[0.75rem] leading-[126%] font-semibold tracking-[-0.02em] text-neutral-100">

--- a/src/components/mainPage/QuickMenuButton.tsx
+++ b/src/components/mainPage/QuickMenuButton.tsx
@@ -72,7 +72,7 @@ export default function QuickActionGrid() {
               strokeWidth={0}
             />
           </div>
-          <span className="mt-2 text-[1rem] font-semibold text-neutral-100">
+          <span className="mt-2 text-[0.875rem] font-semibold text-neutral-100">
             사진 복원하기
           </span>
         </ActionCard>
@@ -85,7 +85,7 @@ export default function QuickActionGrid() {
           <div className="flex size-8 items-center justify-center">
             <MainCamera className="size-8 text-[#FF5A00]" strokeWidth={2} />
           </div>
-          <span className="mt-2 text-[1rem] font-semibold text-neutral-100">
+          <span className="mt-2 text-[0.875rem] font-semibold text-neutral-100">
             필카 입문 101
           </span>
         </ActionCard>

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,2 +1,3 @@
 export { useDebouncedValue } from "./useDebounceValue";
 export { useAnchorScroll } from "./useAnchorScroll";
+export { useHorizontalScrollRestore } from "./useHorizontalScrollRestore";

--- a/src/hooks/common/useHorizontalScrollRestore.ts
+++ b/src/hooks/common/useHorizontalScrollRestore.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 type ScrollAnchorData = {
   anchorId: string;
@@ -16,7 +16,10 @@ export function useHorizontalScrollRestore(
   scrollRef: React.RefObject<HTMLElement | null>,
   sectionId: string,
 ) {
-  const STORAGE_KEY = `horizontal_scroll_anchor_${sectionId}`;
+  const STORAGE_KEY = useMemo(
+    () => `horizontal_scroll_anchor_${sectionId}`,
+    [sectionId],
+  );
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -82,7 +85,7 @@ export function useHorizontalScrollRestore(
       container.removeEventListener("touchstart", onUserInteraction);
       container.removeEventListener("wheel", onUserInteraction);
     };
-  }, [scrollRef, sectionId]);
+  }, [scrollRef, STORAGE_KEY]);
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -138,7 +141,7 @@ export function useHorizontalScrollRestore(
       container.removeEventListener("scroll", onScroll);
       clearTimeout(debounceTimer);
     };
-  }, [scrollRef, sectionId]);
+  }, [scrollRef, STORAGE_KEY]);
 
   const hasRestoredPosition = () => {
     return !!sessionStorage.getItem(STORAGE_KEY);

--- a/src/hooks/common/useHorizontalScrollRestore.ts
+++ b/src/hooks/common/useHorizontalScrollRestore.ts
@@ -1,0 +1,148 @@
+import { useEffect } from "react";
+
+type ScrollAnchorData = {
+  anchorId: string;
+  offset: number;
+};
+
+function isScrollAnchorData(value: unknown): value is ScrollAnchorData {
+  if (!value || typeof value !== "object") return false;
+
+  const v = value as Record<string, unknown>;
+  return typeof v.anchorId === "string" && typeof v.offset === "number";
+}
+
+export function useHorizontalScrollRestore(
+  scrollRef: React.RefObject<HTMLElement | null>,
+  sectionId: string,
+) {
+  const STORAGE_KEY = `horizontal_scroll_anchor_${sectionId}`;
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stored);
+    } catch (error) {
+      console.error("Failed to parse scroll anchor data:", error);
+      return;
+    }
+
+    if (!isScrollAnchorData(parsed)) return;
+
+    const { anchorId, offset } = parsed;
+
+    let isUserInteracting = false;
+    const onUserInteraction = () => {
+      isUserInteracting = true;
+    };
+
+    container.addEventListener("touchstart", onUserInteraction, {
+      passive: true,
+    });
+    container.addEventListener("wheel", onUserInteraction, { passive: true });
+
+    const restore = () => {
+      if (isUserInteracting) return;
+
+      const anchor = container.querySelector(
+        `[data-anchor-id="${anchorId}"]`,
+      ) as HTMLElement | null;
+
+      if (!anchor) return;
+
+      const targetScroll = anchor.offsetLeft + offset;
+
+      if (Math.abs(container.scrollLeft - targetScroll) > 1) {
+        container.scrollLeft = targetScroll;
+      }
+    };
+
+    const observer = new MutationObserver(() => {
+      requestAnimationFrame(restore);
+    });
+
+    observer.observe(container, { childList: true, subtree: true });
+    requestAnimationFrame(restore);
+
+    const timeoutId = setTimeout(() => {
+      observer.disconnect();
+      container.removeEventListener("touchstart", onUserInteraction);
+      container.removeEventListener("wheel", onUserInteraction);
+    }, 5000);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(timeoutId);
+      container.removeEventListener("touchstart", onUserInteraction);
+      container.removeEventListener("wheel", onUserInteraction);
+    };
+  }, [scrollRef, sectionId]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const children = Array.from(container.children) as HTMLElement[];
+      const scrollLeft = container.scrollLeft;
+
+      let bestAnchor: HTMLElement | null = null;
+
+      for (const child of children) {
+        if (!child.hasAttribute("data-anchor-id")) continue;
+
+        const left = child.offsetLeft;
+        const width = child.offsetWidth;
+
+        if (left <= scrollLeft && left + width > scrollLeft) {
+          bestAnchor = child;
+          break;
+        }
+      }
+
+      if (
+        !bestAnchor &&
+        children.length > 0 &&
+        scrollLeft < children[0].offsetLeft
+      ) {
+        bestAnchor =
+          children.find((c) => c.hasAttribute("data-anchor-id")) || null;
+      }
+
+      if (!bestAnchor) return;
+
+      const anchorId = bestAnchor.getAttribute("data-anchor-id");
+      if (!anchorId) return;
+
+      const offset = scrollLeft - bestAnchor.offsetLeft;
+
+      const payload: ScrollAnchorData = { anchorId, offset };
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    };
+
+    let debounceTimer: ReturnType<typeof setTimeout>;
+    const onScroll = () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(handleScroll, 100);
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+
+    return () => {
+      container.removeEventListener("scroll", onScroll);
+      clearTimeout(debounceTimer);
+    };
+  }, [scrollRef, sectionId]);
+
+  const hasRestoredPosition = () => {
+    return !!sessionStorage.getItem(STORAGE_KEY);
+  };
+
+  return { hasRestoredPosition };
+}

--- a/src/hooks/common/useHorizontalScrollRestore.ts
+++ b/src/hooks/common/useHorizontalScrollRestore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 type ScrollAnchorData = {
   anchorId: string;
@@ -92,7 +92,10 @@ export function useHorizontalScrollRestore(
     if (!container) return;
 
     const handleScroll = () => {
-      const children = Array.from(container.children) as HTMLElement[];
+      const children = Array.from(container.children).filter(
+        (child): child is HTMLElement => child instanceof HTMLElement,
+      );
+
       const scrollLeft = container.scrollLeft;
 
       let bestAnchor: HTMLElement | null = null;
@@ -143,9 +146,9 @@ export function useHorizontalScrollRestore(
     };
   }, [scrollRef, STORAGE_KEY]);
 
-  const hasRestoredPosition = () => {
+  const hasRestoredPosition = useCallback(() => {
     return !!sessionStorage.getItem(STORAGE_KEY);
-  };
+  }, [STORAGE_KEY]);
 
   return { hasRestoredPosition };
 }


### PR DESCRIPTION
## 🔀 Pull Request Title

메인페이지 3차 QA 반영
- Closes #192 

<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

### `useHorizontalScrollRestore.ts`
> 스크롤 위치를 “anchor + offset”으로 저장하는 부분
```ts
const anchorId = bestAnchor.getAttribute("data-anchor-id");
const offset = scrollLeft - bestAnchor.offsetLeft;

const payload: ScrollAnchorData = { anchorId, offset };
sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
```

> DOM 준비 타이밍을 고려한 복원 로직
```ts
const observer = new MutationObserver(() => {
  requestAnimationFrame(restore);
});

observer.observe(container, { childList: true, subtree: true });
requestAnimationFrame(restore);

const targetScroll = anchor.offsetLeft + offset;

if (Math.abs(container.scrollLeft - targetScroll) > 1) {
  container.scrollLeft = targetScroll;
}

```
<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [X] /photo-labs/notices 서버 수정 확인
- [X] 퀵 메뉴 버튼 폰트 확인 (디자이너 QA)
- [X] TC-HM-015 캐러셀 선택후 돌아올 때 직전 화면(클릭 직전 화면)이 노출되도록 변경 (추가 QA)
- [X] TC-HM-019 캐러셀 선택후 돌아올 때 직전 화면(클릭 직전 화면)이 노출되도록 변경 (추가 QA)
- [X] 메인 로고 클릭 인터렉션 삭제

<br>