### PR TITLE
[REFACTOR] 현상소 보기 3차 QA 반영

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -34,14 +34,23 @@ export default function SearchBar({
   onClear,
 }: SearchBarProps) {
   const [localValue, setLocalValue] = useState(value);
+  // 마지막으로 onChange로 보낸 값 추적 (ref 대신 state로, lint..)
+  const [lastEmitted, setLastEmitted] = useState(value);
 
-  useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
+  // 외부 변경만 동기화
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (value !== lastEmitted) {
+      setLocalValue(value);
+    }
+    setLastEmitted(value);
+  }
 
   useEffect(() => {
     const timer = setTimeout(() => {
       if (localValue !== value) {
+        setLastEmitted(localValue);
         onChange(localValue);
       }
     }, debounceMs);
@@ -51,6 +60,7 @@ export default function SearchBar({
 
   const handleClear = () => {
     setLocalValue("");
+    setLastEmitted("");
     onChange("");
     onClear?.();
     inputRef?.current?.blur();

--- a/src/components/common/chips/DateChip.tsx
+++ b/src/components/common/chips/DateChip.tsx
@@ -27,7 +27,7 @@ export default function DateChip({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`relative flex h-[3rem] w-[3rem] items-center justify-center rounded-[0.625rem] px-[0.875rem] py-[0.375rem] transition-colors ${
+      className={`flex h-[3rem] w-[3rem] flex-col items-center justify-center rounded-[0.625rem] px-[0.875rem] py-[0.375rem] transition-colors ${
         selected ? "bg-orange-500" : ""
       } ${disabled ? "cursor-not-allowed" : ""} ${className}`}
     >
@@ -36,13 +36,11 @@ export default function DateChip({
       >
         {day}
       </span>
-      {label && (
-        <span
-          className={`absolute bottom-[0.25rem] text-[0.625rem] leading-[126%] font-normal tracking-[-0.02em] ${getTextColor()}`}
-        >
-          {label}
-        </span>
-      )}
+      <span
+        className={`text-[0.625rem] leading-[126%] font-normal tracking-[-0.02em] ${label ? getTextColor() : "invisible"}`}
+      >
+        {label || "\u00A0"}
+      </span>
     </button>
   );
 }

--- a/src/components/photoLab/Calendar.tsx
+++ b/src/components/photoLab/Calendar.tsx
@@ -81,11 +81,11 @@ export default function Calendar({
       </div>
 
       {/* 요일 헤더 */}
-      <div className="grid grid-cols-7 gap-x-[0.125rem] px-[0.4375rem]">
+      <div className="grid grid-cols-7 justify-items-center gap-x-[0.125rem]">
         {WEEKDAYS.map((day) => (
           <div
             key={day}
-            className="flex h-[1.375rem] items-center justify-center text-[0.875rem] leading-[154%] font-normal tracking-[-0.02em] text-neutral-100"
+            className="flex h-[1.375rem] w-[3rem] items-center justify-center text-[0.875rem] leading-[154%] font-normal tracking-[-0.02em] text-neutral-100"
           >
             {day}
           </div>
@@ -93,7 +93,7 @@ export default function Calendar({
       </div>
 
       {/* 날짜 그리드 */}
-      <div className="grid grid-cols-7 gap-x-[0.125rem] gap-y-[0.125rem]">
+      <div className="grid grid-cols-7 justify-items-center gap-x-[0.125rem] gap-y-[0.125rem]">
         {visibleDays.map(({ date, isCurrentMonth }, index) => {
           if (!isCurrentMonth) {
             return (

--- a/src/components/photoLab/detail/LabImageCarousel.tsx
+++ b/src/components/photoLab/detail/LabImageCarousel.tsx
@@ -30,6 +30,8 @@ export default function LabImageCarousel({
               src={src}
               alt={`${altPrefix}-${i + 1}`}
               className="h-[13.6875rem] w-full object-cover"
+              loading={i === 0 ? "eager" : "lazy"}
+              fetchPriority={i === 0 ? "high" : "auto"}
               draggable={false}
             />
           </div>

--- a/src/components/photoLab/detail/LabWorkResultsSection.tsx
+++ b/src/components/photoLab/detail/LabWorkResultsSection.tsx
@@ -47,6 +47,7 @@ export default function LabWorkResultsSection({
               key={index}
               src={url}
               alt={`작업 결과물 ${index + 1}`}
+              loading="lazy"
               className="max-h-full w-auto rounded-[0.625rem] object-contain"
             />
           ))}

--- a/src/components/photoLab/search/LabPreviewSkeleton.tsx
+++ b/src/components/photoLab/search/LabPreviewSkeleton.tsx
@@ -1,0 +1,22 @@
+const SKELETON_COUNT = 5;
+
+export default function LabPreviewSkeleton() {
+  return (
+    <div className="flex flex-col gap-3.5">
+      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+        <div
+          key={`preview-skeleton-${i}`}
+          className="flex items-center gap-3.5"
+        >
+          {/* 이미지 */}
+          <div className="h-[2.875rem] w-[2.875rem] shrink-0 animate-pulse rounded-[0.625rem] bg-neutral-800" />
+          {/* 텍스트 */}
+          <div className="flex flex-1 flex-col gap-1.5">
+            <div className="h-[0.875rem] w-32 animate-pulse rounded bg-neutral-800" />
+            <div className="h-[0.75rem] w-48 animate-pulse rounded bg-neutral-800" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/photoLab/search/index.ts
+++ b/src/components/photoLab/search/index.ts
@@ -5,3 +5,4 @@ export { default as LabPreviewItem } from "./LabPreviewItem";
 export { default as LabPreviewSection } from "./LabPreviewSection";
 export { default as KeywordSuggestionSection } from "./KeywordSuggestionSection";
 export { default as PopularLabSkeleton } from "./PopularLabSkeleton";
+export { default as LabPreviewSkeleton } from "./LabPreviewSkeleton";

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router";
 import { CTA_Button, SearchBar } from "@/components/common";
 import PhotoCard from "@/components/photoFeed/mainFeed/PhotoCard";
@@ -43,8 +43,8 @@ export default function PhotoFeedSearchPage() {
   const location = useLocation();
   const initialLabName = location.state?.labName as string | undefined;
 
-  useEffect(() => {
-    window.scrollTo(0, 0);
+  useLayoutEffect(() => {
+    document.getElementById("root")?.scrollTo(0, 0);
   }, []);
 
   const [filter, setFilter] = useState<Filter>(

--- a/src/pages/photoLab/PhotoLabDetailPage.tsx
+++ b/src/pages/photoLab/PhotoLabDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Header } from "@/components/common";
 import {
@@ -30,8 +30,8 @@ export default function PhotoLabDetailPage() {
     latitude && longitude ? { lat: latitude, lng: longitude } : undefined,
   );
 
-  useEffect(() => {
-    window.scrollTo(0, 0);
+  useLayoutEffect(() => {
+    document.getElementById("root")?.scrollTo(0, 0);
   }, []);
 
   const handleBack = () => {

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -11,6 +11,7 @@ import {
   PopularLabSkeleton,
   RecentSearchSection,
   LabPreviewSection,
+  LabPreviewSkeleton,
 } from "@/components/photoLab/search";
 import { useRecentSearches } from "@/hooks/common/useRecentSearches";
 import { useDebouncedValue } from "@/hooks/common";
@@ -71,15 +72,18 @@ export default function PhotoLabSearchPage() {
 
   // 검색 미리보기 (경량 API)
   const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
-  const { data: filteredLabPreviews = [], isPlaceholderData: isPreviewStale } =
-    useSearchPreview(
-      {
-        q: debouncedQuery,
-        lat: latitude ?? undefined,
-        lng: longitude ?? undefined,
-      },
-      !isResultsState,
-    );
+  const {
+    data: filteredLabPreviews = [],
+    isPending: isPreviewPending,
+    isPlaceholderData: isPreviewStale,
+  } = useSearchPreview(
+    {
+      q: debouncedQuery,
+      lat: latitude ?? undefined,
+      lng: longitude ?? undefined,
+    },
+    !isResultsState,
+  );
 
   // 검색 결과 API 연동
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -212,10 +216,14 @@ export default function PhotoLabSearchPage() {
             isPreviewStale ? "opacity-40" : "opacity-100"
           }`}
         >
-          <LabPreviewSection
-            labs={filteredLabPreviews}
-            onLabClick={handleLabClick}
-          />
+          {isPreviewPending && !isPreviewStale ? (
+            <LabPreviewSkeleton />
+          ) : (
+            <LabPreviewSection
+              labs={filteredLabPreviews}
+              onLabClick={handleLabClick}
+            />
+          )}
         </div>
       )}
 

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -10,7 +10,6 @@ import {
   PopularLabSection,
   PopularLabSkeleton,
   RecentSearchSection,
-  KeywordSuggestionSection,
   LabPreviewSection,
 } from "@/components/photoLab/search";
 import { useRecentSearches } from "@/hooks/common/useRecentSearches";
@@ -20,7 +19,6 @@ import {
   usePhotoLabList,
   useFavoriteToggle,
   useGeolocation,
-  useAutocomplete,
   useSearchPreview,
 } from "@/hooks/photoLab";
 import { displayTimesToApiTimes } from "@/utils/time";
@@ -70,10 +68,6 @@ export default function PhotoLabSearchPage() {
   const { filter, setFilter, selectedTagIds, setSelectedTagIds } =
     usePhotoLabFilter();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-
-  // 키워드 자동완성
-  const { data: filteredKeywords = [], isPlaceholderData: isKeywordStale } =
-    useAutocomplete(query);
 
   // 검색 미리보기 (경량 API)
   const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
@@ -157,13 +151,6 @@ export default function PhotoLabSearchPage() {
     });
   };
 
-  const handleKeywordClick = (keyword: string) => {
-    addSearch(keyword);
-    navigate(`/photolab/search?q=${encodeURIComponent(keyword)}`, {
-      replace: true,
-    });
-  };
-
   const handleSearchBarClick = () => {
     if (isResultsState) {
       setQuery(searchQuery);
@@ -221,15 +208,10 @@ export default function PhotoLabSearchPage() {
       {/* PL-011-2: 검색어 입력 중 */}
       {!isResultsState && query.trim() && (
         <div
-          className={`flex flex-col gap-[1.875rem] pt-5 transition-opacity duration-200 ${
-            isKeywordStale || isPreviewStale ? "opacity-40" : "opacity-100"
+          className={`pt-5 transition-opacity duration-200 ${
+            isPreviewStale ? "opacity-40" : "opacity-100"
           }`}
         >
-          <KeywordSuggestionSection
-            keywords={filteredKeywords}
-            query={query}
-            onKeywordClick={handleKeywordClick}
-          />
           <LabPreviewSection
             labs={filteredLabPreviews}
             onLabClick={handleLabClick}

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -267,16 +267,16 @@ export default function PhotoLabSearchPage() {
             emptyMessage="검색 결과가 없어요"
             className="pt-4"
           />
-
-          {/* 필터 바텀시트 */}
-          <FilterBottomSheet
-            open={isFilterOpen}
-            onClose={() => setIsFilterOpen(false)}
-            initialFilter={filter}
-            onApply={setFilter}
-          />
         </>
       )}
+
+      {/* 필터 바텀시트 (vh 초기값 유지) */}
+      <FilterBottomSheet
+        open={isFilterOpen}
+        onClose={() => setIsFilterOpen(false)}
+        initialFilter={filter}
+        onApply={setFilter}
+      />
     </div>
   );
 }

--- a/src/pages/photoLab/PhotoLabSearchPage.tsx
+++ b/src/pages/photoLab/PhotoLabSearchPage.tsx
@@ -132,6 +132,7 @@ export default function PhotoLabSearchPage() {
   // 뒤로가기: 검색 결과 → 검색 입력, 검색 입력 → 현상소 목록
   const handleBack = () => {
     if (isResultsState) {
+      setQuery("");
       navigate("/photolab/search", { replace: true });
     } else {
       navigate("/photolab", { replace: true });

--- a/src/pages/photoLab/ReservationCompletePage.tsx
+++ b/src/pages/photoLab/ReservationCompletePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useLayoutEffect, useMemo } from "react";
 import { useNavigate, useLocation, useParams } from "react-router";
 import { Header } from "@/components/common";
 import { LabLocationSection } from "@/components/photoLab/detail";
@@ -52,8 +52,8 @@ export default function ReservationCompletePage() {
     return formatKoreanDateTime(reservation.estimatedCompletion);
   }, [reservation]);
 
-  useEffect(() => {
-    window.scrollTo(0, 0);
+  useLayoutEffect(() => {
+    document.getElementById("root")?.scrollTo(0, 0);
   }, []);
 
   const handleClose = () => {

--- a/src/pages/photoLab/ReservationPage.tsx
+++ b/src/pages/photoLab/ReservationPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { useState, useCallback, useMemo, useRef, useLayoutEffect } from "react";
 import { useNavigate, useLocation, useParams } from "react-router";
 import {
   Header,
@@ -70,8 +70,8 @@ export default function ReservationPage() {
   const { data: availableTimes } = useAvailableTimes(labId, dateKey);
   const { mutate: createReservation } = useCreateReservation();
 
-  useEffect(() => {
-    window.scrollTo(0, 0);
+  useLayoutEffect(() => {
+    document.getElementById("root")?.scrollTo(0, 0);
   }, []);
 
   const handleBack = useCallback(() => {


### PR DESCRIPTION
## 🔀 Pull Request Title

현상소 보기 3차 QA 반영

- Closes #203 

<br>

## 📌 PR 설명

- [x] TC-PL-027 (검색어 입력 중일 때, 해당 피처는 mvp에서 제외, UI 제거)
- [x] TC-PL-031 (검색 결과 화면에서 필터 클릭하면 바텀시트 높이 문제)
- [x] TC-PL-0311 (검색 결과 화면에서 ‘헤더’ 뒤로가기 클릭 시 pl-011-1로 이동)
- [x] PL-011-2 입력된 검색어 UX 확인
- [x] 전체적으로 스크롤 리셋 확인
- [x] LazyLoading적용
- [x] Calendar UI Figma와 교차 검증 필요
- [x] PL-011-2에 skeleton 적용

## 📷 스크린샷
<img width="537" height="394" alt="image" src="https://github.com/user-attachments/assets/115a584a-be6b-45d1-adf1-116a0d4a0ad2" />
<img width="410" height="377" alt="image" src="https://github.com/user-attachments/assets/d9189a7a-aac7-4fa7-8ce6-c556df309d59" />
<img width="416" height="376" alt="image" src="https://github.com/user-attachments/assets/b5939171-1292-4624-82a3-1b6759780389" />



<br>
