### PR TITLE
[REFACTOR] 메인페이지 4차 QA 반영

### DIFF
--- a/src/components/mainPage/Header.tsx
+++ b/src/components/mainPage/Header.tsx
@@ -1,7 +1,7 @@
 export default function Header() {
   return (
-    <header className="sticky top-0 z-50 flex h-14 w-full items-center justify-between bg-neutral-900">
-      <div>
+    <header className="z-50 w-full bg-neutral-900 pt-[env(safe-area-inset-top)]">
+      <div className="flex h-14 items-center justify-between">
         <div className="font-ydestreet text-[1.625rem] leading-[132%] font-bold text-neutral-100">
           Finders
         </div>

--- a/src/components/mainPage/NoticeSection/NoticeSection.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSection.tsx
@@ -20,7 +20,7 @@ export default function NoticeSection() {
       {/* 가로 스크롤 리스트 */}
       <div
         ref={containerRef}
-        className="scrollbar-hide relative flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-34"
+        className="scrollbar-hide relative flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-18"
       >
         {notices.map((notice, index) => {
           const anchorId = `notice-${notice.photoLabId}-${index}`;

--- a/src/components/mainPage/NoticeSection/NoticeSection.tsx
+++ b/src/components/mainPage/NoticeSection/NoticeSection.tsx
@@ -20,7 +20,7 @@ export default function NoticeSection() {
       {/* 가로 스크롤 리스트 */}
       <div
         ref={containerRef}
-        className="scrollbar-hide relative flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-20"
+        className="scrollbar-hide relative flex w-full snap-x snap-mandatory gap-3 overflow-x-auto px-5 pb-34"
       >
         {notices.map((notice, index) => {
           const anchorId = `notice-${notice.photoLabId}-${index}`;

--- a/src/hooks/photoFeed/reactions/useLikePost.ts
+++ b/src/hooks/photoFeed/reactions/useLikePost.ts
@@ -1,6 +1,10 @@
 import { postLike } from "@/apis/photoFeed";
 import type { PostDetailResponse } from "@/types/photoFeed/postDetail";
+import type { CommunityPost } from "@/apis/mainPage/mainPage.api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const COMMUNITY_PREVIEW_QK = ["community", "posts", "preview"] as const;
+const POST_DETAIL_QK = (postId: number) => ["postDetail", postId] as const;
 
 export function useLikePost() {
   const queryClient = useQueryClient();
@@ -10,12 +14,19 @@ export function useLikePost() {
     mutationFn: (postId: number) => postLike(postId),
 
     onMutate: async (postId) => {
-      await queryClient.cancelQueries({ queryKey: ["postDetail", postId] });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: POST_DETAIL_QK(postId) }),
+        queryClient.cancelQueries({ queryKey: COMMUNITY_PREVIEW_QK }),
+      ]);
 
-      const prev = queryClient.getQueryData(["postDetail", postId]);
+      const prevDetail = queryClient.getQueryData<PostDetailResponse>(
+        POST_DETAIL_QK(postId),
+      );
+      const prevPreview =
+        queryClient.getQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK);
 
       queryClient.setQueryData(
-        ["postDetail", postId],
+        POST_DETAIL_QK(postId),
         (old?: PostDetailResponse) =>
           old
             ? {
@@ -26,20 +37,33 @@ export function useLikePost() {
             : old,
       );
 
-      return { prev };
+      queryClient.setQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK, (old) =>
+        old?.map((p) =>
+          p.postId === postId
+            ? {
+                ...p,
+                isLiked: true,
+                likeCount: p.likeCount + 1,
+              }
+            : p,
+        ),
+      );
+
+      return { prevDetail, prevPreview };
     },
 
     onError: (_err, postId, context) => {
-      if (context?.prev) {
-        queryClient.setQueryData(["postDetail", postId], context.prev);
+      if (context?.prevDetail) {
+        queryClient.setQueryData(POST_DETAIL_QK(postId), context.prevDetail);
+      }
+      if (context?.prevPreview) {
+        queryClient.setQueryData(COMMUNITY_PREVIEW_QK, context.prevPreview);
       }
     },
 
     onSuccess: (_data, postId) => {
-      // 게시글 상세 갱신
-      queryClient.invalidateQueries({
-        queryKey: ["postDetail", postId],
-      });
+      queryClient.invalidateQueries({ queryKey: POST_DETAIL_QK(postId) });
+      queryClient.invalidateQueries({ queryKey: COMMUNITY_PREVIEW_QK });
     },
   });
 }

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -42,17 +42,11 @@ export default function MainPage() {
   useAnchorScroll(scrollRef);
 
   return (
-    <div className="mx-auto h-dvh w-full max-w-sm bg-neutral-900 text-white">
-      {" "}
+    <div className="mx-auto flex h-dvh w-full max-w-sm flex-col bg-neutral-900 text-white">
       <Header />
       <div
         ref={scrollRef}
-        style={{
-          WebkitOverflowScrolling: "auto",
-          touchAction: "pan-y",
-          overflowAnchor: "none",
-        }}
-        className="scrollbar-hide mx-auto h-dvh w-full max-w-sm overflow-y-auto overscroll-y-none bg-neutral-900 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-white"
+        className="scrollbar-hide flex-1 overflow-y-auto overscroll-y-none pb-[env(safe-area-inset-bottom)]"
       >
         <SectionWrapper id="promotion">
           <PromotionBanner />

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -42,36 +42,37 @@ export default function MainPage() {
   useAnchorScroll(scrollRef);
 
   return (
-    <div
-      ref={scrollRef}
-      style={{
-        WebkitOverflowScrolling: "auto",
-        touchAction: "pan-y",
-        overflowAnchor: "none",
-      }}
-      className="scrollbar-hide mx-auto h-dvh w-full max-w-sm overflow-y-auto overscroll-y-none bg-neutral-900 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-white"
-    >
-      <SectionWrapper id="header">
-        <Header />
-      </SectionWrapper>
-      <SectionWrapper id="promotion">
-        <PromotionBanner />
-      </SectionWrapper>
-      <SectionWrapper id="quick-menu">
-        <QuickMenuButton />
-      </SectionWrapper>
-      <SectionWrapper id="popular-labs">
-        <PopularLabsSection />
-      </SectionWrapper>
-      <SectionWrapper id="film-news">
-        <FilmNewsSection />
-      </SectionWrapper>
-      <SectionWrapper id="community">
-        <CommunityGallerySection />
-      </SectionWrapper>
-      <SectionWrapper id="notice">
-        <NoticeSection />
-      </SectionWrapper>
+    <div className="mx-auto h-dvh w-full max-w-sm bg-neutral-900 text-white">
+      {" "}
+      <Header />
+      <div
+        ref={scrollRef}
+        style={{
+          WebkitOverflowScrolling: "auto",
+          touchAction: "pan-y",
+          overflowAnchor: "none",
+        }}
+        className="scrollbar-hide mx-auto h-dvh w-full max-w-sm overflow-y-auto overscroll-y-none bg-neutral-900 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-white"
+      >
+        <SectionWrapper id="promotion">
+          <PromotionBanner />
+        </SectionWrapper>
+        <SectionWrapper id="quick-menu">
+          <QuickMenuButton />
+        </SectionWrapper>
+        <SectionWrapper id="popular-labs">
+          <PopularLabsSection />
+        </SectionWrapper>
+        <SectionWrapper id="film-news">
+          <FilmNewsSection />
+        </SectionWrapper>
+        <SectionWrapper id="community">
+          <CommunityGallerySection />
+        </SectionWrapper>
+        <SectionWrapper id="notice">
+          <NoticeSection />
+        </SectionWrapper>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔀 Pull Request Title
메인페이지 4차 QA를 반영합니다. 
- Closes #247 

<br>

## 🎞️ 주요 코드 설명 
### `CommunityGallerySectionCard.tsx`
> 게시글 좋아요 상태를 로컬 useState 기반에서 React Query mutation 기반으로 리팩토링했습니다.
optimistic update → 실패 시 rollback → onSettled에서 캐시 invalidate 흐름으로 동작하며, 목록에서 좋아요 상태가 즉시 반영되도록 개선했습니다.
```ts
const likeMutation = useMutation({
  mutationFn: ({ postId, nextLiked }) =>
    nextLiked ? likePost(postId) : unlikePost(postId),

  onMutate: async ({ postId, nextLiked }) => {
    await queryClient.cancelQueries({ queryKey: COMMUNITY_PREVIEW_QK });

    const previous = queryClient.getQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK);

    queryClient.setQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK, (prev) =>
      patchCommunityPreviewPost(prev, postId, (p) => ({
        ...p,
        isLiked: nextLiked,
        likeCount: Math.max(0, p.likeCount + (nextLiked ? 1 : -1)),
      })),
    );

    return { previous };
  },

  onError: (_err, _vars, ctx) => {
    if (ctx?.previous) {
      queryClient.setQueryData(COMMUNITY_PREVIEW_QK, ctx.previous);
    }
  },

  onSettled: () => {
    queryClient.invalidateQueries({ queryKey: COMMUNITY_PREVIEW_QK });
  },
});

```

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [X] 게시글 좋아요 동기화 적용
- [X] sticky 헤더 재적용

<br>

## 📷 스크린샷

<img width="481" height="721" alt="image" src="https://github.com/user-attachments/assets/71cfc53d-f1df-4870-82a7-47b738f0bf64" />
<br>
