### PR TITLE
[REFACTOR] ios apple sign in with token

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+
 
 pnpm lint-staged

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,6 +8,14 @@ const config: CapacitorConfig = {
   ios: {
     packageManager: "cocoapods",
   },
+  plugins: {
+    CapacitorCookies: {
+      enabled: true,
+    },
+    CapacitorHttp: {
+      enabled: true,
+    },
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.4",
     "@capacitor/ios": "^8.3.4",
+    "@capacitor/splash-screen": "^8.0.1",
     "@tanstack/react-query": "^5.90.12",
     "axios": "^1.13.2",
     "capacitor-secure-storage-plugin": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "cap:open:android": "npx cap open android"
   },
   "dependencies": {
+    "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor/android": "^8.3.4",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.4",
     "@capacitor/ios": "^8.3.4",
     "@tanstack/react-query": "^5.90.12",
     "axios": "^1.13.2",
+    "capacitor-secure-storage-plugin": "^0.13.0",
     "capacitor3-kakao-login": "^0.8.7",
     "jwt-decode": "^4.0.0",
     "pretendard": "^1.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@capacitor/ios':
         specifier: ^8.3.4
         version: 8.3.4(@capacitor/core@8.3.4)
+      '@capacitor/splash-screen':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.3.4)
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.3)
@@ -252,6 +255,11 @@ packages:
     resolution: {integrity: sha512-XvvnPFWWP/gwwO811ue7nEBKSZqDCIB8hxGgWV6iXA7DSVLqMOEmQdfHj94kkVxof2wL9XWHypu3ayDULo7U5w==}
     peerDependencies:
       '@capacitor/core': ^8.3.0
+
+  '@capacitor/splash-screen@8.0.1':
+    resolution: {integrity: sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -2429,6 +2437,10 @@ snapshots:
       tslib: 2.8.1
 
   '@capacitor/ios@8.3.4(@capacitor/core@8.3.4)':
+    dependencies:
+      '@capacitor/core': 8.3.4
+
+  '@capacitor/splash-screen@8.0.1(@capacitor/core@8.3.4)':
     dependencies:
       '@capacitor/core': 8.3.4
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@capacitor-community/apple-sign-in':
+        specifier: ^7.1.0
+        version: 7.1.0(@capacitor/core@8.3.4)
       '@capacitor/android':
         specifier: ^8.3.4
         version: 8.3.4(@capacitor/core@8.3.4)
@@ -30,6 +33,9 @@ importers:
       axios:
         specifier: ^1.13.2
         version: 1.13.2
+      capacitor-secure-storage-plugin:
+        specifier: ^0.13.0
+        version: 0.13.0(@capacitor/core@8.3.4)
       capacitor3-kakao-login:
         specifier: ^0.8.7
         version: 0.8.7(@capacitor/core@8.3.4)
@@ -218,6 +224,11 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@capacitor-community/apple-sign-in@7.1.0':
+    resolution: {integrity: sha512-df7cA7vfvvvilTtpJKeVvxO31W+py5t3HK9233GBD5MvgAgtGvCqeQ3pI0noNkVsKPF9B1g/po8Mph6s4bVSmw==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
 
   '@capacitor/android@8.3.4':
     resolution: {integrity: sha512-7gJjrG3X32Am1QMLqgMztWTYMLMVNE+VZwhekNxhvYizH4mOV05vH+rC9B+f17bCkYZfyu/qXQX6hoY7kLeVZw==}
@@ -843,6 +854,9 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/scriptjs@0.0.2':
+    resolution: {integrity: sha512-GFrUgzGYfNX3VWZwMyzr0JrBwzLv5Kes4BQBvo6hXdRy14/GBbpCiVwwB7v1o2xIEvFf+9GyznmYhuesQQjSag==}
+
   '@types/slice-ansi@4.0.0':
     resolution: {integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==}
 
@@ -1026,6 +1040,11 @@ packages:
 
   caniuse-lite@1.0.30001761:
     resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
+
+  capacitor-secure-storage-plugin@0.13.0:
+    resolution: {integrity: sha512-+rLC/9Z0LTaRRt6L6HjBwcDh5gqgI3NPmDSwo4hk41XQOy3EBrRo81VleIqFsowsMA3oMT+E59Bl8/HiWk0nhQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   capacitor3-kakao-login@0.8.7:
     resolution: {integrity: sha512-GSElGfcwB/iVjPXxr28ACBmkGNdDsWZK1AvqT6Q9M3NOlf4QbFF5j/hy8AlahwR3ltrB3Lw2+ktUvA+6PwRs4Q==}
@@ -1948,6 +1967,9 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  scriptjs@2.5.9:
+    resolution: {integrity: sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2365,6 +2387,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@capacitor-community/apple-sign-in@7.1.0(@capacitor/core@8.3.4)':
+    dependencies:
+      '@capacitor/core': 8.3.4
+      '@types/scriptjs': 0.0.2
+      scriptjs: 2.5.9
 
   '@capacitor/android@8.3.4(@capacitor/core@8.3.4)':
     dependencies:
@@ -2919,6 +2947,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/scriptjs@0.0.2': {}
+
   '@types/slice-ansi@4.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
@@ -3122,6 +3152,10 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001761: {}
+
+  capacitor-secure-storage-plugin@0.13.0(@capacitor/core@8.3.4):
+    dependencies:
+      '@capacitor/core': 8.3.4
 
   capacitor3-kakao-login@0.8.7(@capacitor/core@8.3.4):
     dependencies:
@@ -3961,6 +3995,8 @@ snapshots:
   sax@1.6.0: {}
 
   scheduler@0.27.0: {}
+
+  scriptjs@2.5.9: {}
 
   semver@6.3.1: {}
 

--- a/src/hooks/auth/login/useAppleLogin.ts
+++ b/src/hooks/auth/login/useAppleLogin.ts
@@ -3,6 +3,9 @@ import { loginWithApple } from "@/utils/auth/appleSdk";
 import { tokenStorage } from "@/utils/tokenStorage";
 import { useOauth } from "./useOauth";
 import { useAuthStore } from "@/store/useAuth.store";
+// 환경 체크 유틸 및 플러그인 임포트 추가
+import { isNativeApp } from "@/utils/auth/envUtils";
+import { SignInWithApple } from "@capacitor-community/apple-sign-in";
 
 type Props = {
   onExistingMember: () => void;
@@ -23,7 +26,6 @@ export function useAppleLogin({
       const data = res.data;
 
       if ("accessToken" in data) {
-        // 기존 회원: accessToken 저장 후 메인으로 (refreshToken은 httpOnly 쿠키)
         tokenStorage.setTokens({
           accessToken: data.accessToken,
           signupToken: null,
@@ -31,7 +33,6 @@ export function useAppleLogin({
         setUser({ memberId: data.member.id, nickname: data.member.nickname });
         onExistingMember();
       } else {
-        // 신규 회원: signupToken 저장 후 약관 동의로
         tokenStorage.setTokens({
           accessToken: null,
           signupToken: data.signupToken,
@@ -45,15 +46,32 @@ export function useAppleLogin({
   const login = async () => {
     try {
       setIsPopupPending(true);
-      const code = await loginWithApple();
+      let code = "";
+
+      // 환경(앱 or 웹_에 따른 로직 분기
+      if (isNativeApp()) {
+        // Capacitor 네이티브 플러그인 호출
+        const result = await SignInWithApple.authorize();
+
+        // 플러그인 결과에서 authorizationCode 추출
+        code = result.response.authorizationCode;
+      } else {
+        // 기존 웹 SDK 호출
+        code = await loginWithApple();
+      }
+
+      if (!code) {
+        throw new Error("인증 코드를 받아오지 못했습니다.");
+      }
+
+      // 백엔드로 코드 전송
       mutate({
         provider: "APPLE",
         credentialType: "AUTHORIZATION_CODE",
         credential: code,
       });
     } catch (e) {
-      // 사용자가 팝업을 닫거나 SDK 로드 실패/환경변수 누락 등
-      console.error(e);
+      console.error("애플 로그인 에러:", e);
       onFail?.();
     } finally {
       setIsPopupPending(false);

--- a/src/lib/setUpInterceptors.ts
+++ b/src/lib/setUpInterceptors.ts
@@ -72,9 +72,9 @@ async function requestRefreshToken(baseURL: string) {
 }
 
 export function setupInterceptors(instance: AxiosInstance) {
-  // Request: accessToken 우선, 없으면 signupToken 첨부
+  // Request: accessToken 우선, 없으면 signupToken 첨부 (비동기로 변경)
   instance.interceptors.request.use(
-    (config: InternalAxiosRequestConfig) => {
+    async (config: InternalAxiosRequestConfig) => {
       const cfg = config as AuthMetaConfig;
 
       if (shouldSkipAuth(cfg)) {
@@ -82,8 +82,9 @@ export function setupInterceptors(instance: AxiosInstance) {
         return cfg;
       }
 
-      const accessToken = tokenStorage.getAccessToken();
-      const signupToken = tokenStorage.getSignupToken();
+      // 비동기 스토리지에서 토큰을 꺼내오므로 await
+      const accessToken = await tokenStorage.getAccessToken();
+      const signupToken = await tokenStorage.getSignupToken();
 
       if (accessToken) {
         cfg.headers = cfg.headers ?? {};
@@ -118,21 +119,19 @@ export function setupInterceptors(instance: AxiosInstance) {
 
       // refresh/reissue 요청이 401이면 더 이상 재시도하지 말고 토큰 정리
       if (shouldSkipAuth(originalConfig)) {
-        tokenStorage.clear();
+        await tokenStorage.clear(); // await 추가
         return Promise.reject(error);
       }
 
       // signupToken으로 붙였던 요청은 refresh 대상이 아님
-      // (온보딩 토큰 만료/무효면 서버가 401 줄 수 있음 -> 그대로 실패 처리 or signupToken만 제거)
       if (originalConfig._authAttached === "signup") {
-        tokenStorage.setSignupToken(null); // 토큰스토리지에 이 메서드 없으면 clear에서 제거만 하거나 직접 remove
+        await tokenStorage.setSignupToken(null); // await 추가
         return Promise.reject(error);
       }
 
-      // accessToken을 붙였던 요청만 refresh 시도
       // 무한 루프 방지
       if (originalConfig._retry) {
-        tokenStorage.clear();
+        await tokenStorage.clear(); // await 추가
         return Promise.reject(error);
       }
       originalConfig._retry = true;
@@ -162,10 +161,13 @@ export function setupInterceptors(instance: AxiosInstance) {
       try {
         const data = await requestRefreshToken(baseURL);
 
-        // 토큰 저장 (signupToken은 그대로 유지, refreshToken은 쿠키로 관리)
-        tokenStorage.setTokens({
+        // 이전 signupToken도 비동기로 꺼내오기
+        const currentSignupToken = await tokenStorage.getSignupToken();
+
+        // 토큰 저장 (await 추가)
+        await tokenStorage.setTokens({
           accessToken: data.accessToken,
-          signupToken: tokenStorage.getSignupToken(),
+          signupToken: currentSignupToken,
         });
 
         // 대기 중인 요청들 처리
@@ -179,7 +181,7 @@ export function setupInterceptors(instance: AxiosInstance) {
         return instance(originalConfig);
       } catch (refreshErr) {
         processQueue(refreshErr, null);
-        tokenStorage.clear();
+        await tokenStorage.clear(); // await 추가
         return Promise.reject(refreshErr);
       } finally {
         isRefreshing = false;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -10,36 +10,57 @@ import { isNativeApp } from "@/utils/auth/envUtils";
 import { oauth } from "@/apis/auth";
 import { tokenStorage } from "@/utils/tokenStorage";
 import { consumeRedirectAfterLogin } from "../demoDay/redirectAfterLogin";
+import { SplashScreen } from "@capacitor/splash-screen"; // 앱 초기 스플래시 제어용
 
 const WELCOME_NONCE_SHOWN_KEY = "finders:welcomeNonceShown";
 const WELCOME_ONCE_FALLBACK_KEY = "finders:welcomeOnceShown";
 
+type AuthCheckStatus = "pending" | "loggedIn" | "loggedOut";
+
 export function LoginPage() {
   const [sp, setSp] = useSearchParams();
-
   const nickname = useAuthStore((s) => s.user?.nickname);
-
   const welcome = sp.get("welcome") === "1";
   const nonce = sp.get("nonce");
+  const navigate = useNavigate();
 
-  //이번 요청에서 welcome을 보여줘야 하는지(세션스토리지 기준)
+  // 자동 로그인(토큰 유무) 상태 관리
+  const [authCheckStatus, setAuthCheckStatus] =
+    useState<AuthCheckStatus>("pending");
+
+  // 앱 실행 시 네이티브 스플래시 숨김 & 백그라운드 토큰 검사
+  useEffect(() => {
+    // 앱인 경우 기본 제공되는 스플래시를 즉시 가리고 리액트 애니메이션 띄우기
+    if (isNativeApp()) {
+      SplashScreen.hide().catch(console.error);
+    }
+
+    const checkToken = async () => {
+      try {
+        const accessToken = await tokenStorage.getAccessToken();
+        setAuthCheckStatus(accessToken ? "loggedIn" : "loggedOut");
+      } catch {
+        setAuthCheckStatus("loggedOut");
+      }
+    };
+
+    checkToken();
+  }, []);
+
+  // 환영 화면 세션스토리지 로직
   const shouldForceNow = useMemo(() => {
     if (!welcome) return false;
     if (typeof window === "undefined") return false;
-
     if (nonce) {
       const shownNonce = sessionStorage.getItem(WELCOME_NONCE_SHOWN_KEY);
       return shownNonce !== nonce;
     }
-
     const shown = sessionStorage.getItem(WELCOME_ONCE_FALLBACK_KEY) === "1";
     return !shown;
   }, [welcome, nonce]);
 
-  // 핵심: ref 없이 "초기값으로만" latch (렌더 중 ref 접근 금지 룰 회피)
   const [forceWelcomeOnce] = useState<boolean>(() => shouldForceNow);
 
-  // latch가 true인 케이스에서만: 기록 + URL 정리
   useEffect(() => {
     if (!forceWelcomeOnce) return;
     if (typeof window === "undefined") return;
@@ -58,12 +79,23 @@ export function LoginPage() {
     );
   }, [forceWelcomeOnce, nonce, setSp]);
 
+  // 애니메이션 훅 실행 (기본 2초 세팅)
   const ui = useLoginIntroUi({
     forceWelcomeOnce,
     splashMs: 2000,
   });
 
-  const navigate = useNavigate();
+  //  애니메이션 완료 & 토큰 검사 완료 시점 동기화하여 라우팅
+  useEffect(() => {
+    // welcome 모드일 때는 자동 라우팅을 막고 사용자가 '홈으로' 버튼을 누르게 함
+    if (ui.mode === "welcome") return;
+
+    // 애니메이션 2초가 끝났고 && 로그인 상태임이 확인되면 -> 메인으로 이동
+    if (!ui.isSplash && authCheckStatus === "loggedIn") {
+      const redirect = consumeRedirectAfterLogin();
+      navigate(redirect ?? "/mainpage", { replace: true });
+    }
+  }, [ui.isSplash, authCheckStatus, ui.mode, navigate]);
 
   const apple = useAppleLogin({
     onExistingMember: () => {
@@ -80,9 +112,7 @@ export function LoginPage() {
         Capacitor3KakaoLogin.initializeKakao({
           app_key: nativeAppKey,
           web_key: "",
-        })
-          .then(() => console.log("카카오 플러그인 초기화 완료!"))
-          .catch((error) => console.error("카카오 초기화 실패:", error));
+        }).catch((error) => console.error("카카오 초기화 실패:", error));
       }
     }
   }, []);
@@ -93,59 +123,48 @@ export function LoginPage() {
     if (isNativeApp()) {
       try {
         const result = await Capacitor3KakaoLogin.kakaoLogin();
-        const accessToken = result.value;
-
         const response = await oauth({
           provider: "KAKAO",
           credentialType: "ACCESS_TOKEN",
-          credential: accessToken,
+          credential: result.value,
         });
 
         const data = response.data;
 
-        // 1. 신규 회원 분기
         if ("isNewMember" in data && data.isNewMember === true) {
-          // 훅에 있던 로직 가져옴 (signupToken 저장)
           tokenStorage.setTokens({
             accessToken: null,
             signupToken: data.signupToken,
           });
           navigate("/auth/onboarding", { replace: true });
-        }
-        // 2. 기존 회원 분기
-        else if ("member" in data) {
-          // 훅에 있던 로직 가져옴 (accessToken 저장 및 전역 상태 세팅)
+        } else if ("member" in data) {
           tokenStorage.setTokens({
             accessToken: data.accessToken,
             signupToken: null,
           });
           setUser({ memberId: data.member.id, nickname: data.member.nickname });
-
-          // const redirect = consumeRedirectAfterLogin();
-          // navigate(redirect ?? "/mainpage", { replace: true });
           navigate("/mainpage", { replace: true });
-        } else {
-          console.error("알 수 없는 로그인 응답 타입입니다:", data);
-          navigate("/auth/login", { replace: true });
         }
       } catch (error) {
-        console.error("앱 카카오 로그인/API 실패:", error);
-        navigate("/auth/login", { replace: true });
+        console.error("앱 카카오 로그인 실패:", error);
       }
     } else {
-      // 일반 웹은 기존처럼 URL 이동 (이후 콜백 페이지에서 올려주신 훅이 알아서 처리함)
-      const url = buildKakaoAuthorizeUrl();
-      window.location.assign(url);
+      window.location.assign(buildKakaoAuthorizeUrl());
     }
   };
 
-  //화면 정책
-  //1.mode=welcome : 축하 화면만
-  //2.mode=normal & isSplash=true : "뷰파인더..." 문구만 2초
-  //3.mode=normal & isSplash=false : 버튼(카카오/둘러보기)
+  // 화면 정책 (번쩍임 방지 로직 적용)
   const showWelcome = ui.mode === "welcome";
-  const showSplash = ui.mode === "normal" && ui.isSplash;
-  const showLogin = ui.mode === "normal" && !ui.isSplash;
+
+  // 훅의 애니메이션이 안 끝났거나 OR 토큰 검사가 아직 안 끝났으면 계속 스플래시 노출
+  const isEffectivelySplash =
+    ui.mode === "normal" && (ui.isSplash || authCheckStatus === "pending");
+
+  // 스플래시도 끝났고, 토큰 검사 결과 로그아웃 상태일 때만 로그인 버튼 노출
+  const showLogin =
+    ui.mode === "normal" &&
+    !isEffectivelySplash &&
+    authCheckStatus === "loggedOut";
 
   return (
     <main className="flex w-full flex-1 flex-col items-center">
@@ -168,7 +187,7 @@ export function LoginPage() {
                 뷰파인더 너머 {nickname}님의 취향을 찾아보세요
               </p>
             </div>
-          ) : showSplash ? (
+          ) : isEffectivelySplash ? (
             <div className={ui.taglineAnim}>
               <p className="font-ydestreet mt-3 text-[2.5rem] leading-none font-extrabold sm:text-[3rem]">
                 Finders
@@ -202,7 +221,7 @@ export function LoginPage() {
               size="compact"
             />
           </div>
-        ) : showSplash ? (
+        ) : isEffectivelySplash ? (
           <div
             key={ui.footerKey}
             className={`mx-auto mb-10 flex w-full max-w-sm justify-center ${ui.footerAnim}`}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -132,13 +132,13 @@ export function LoginPage() {
         const data = response.data;
 
         if ("isNewMember" in data && data.isNewMember === true) {
-          tokenStorage.setTokens({
+          await tokenStorage.setTokens({
             accessToken: null,
             signupToken: data.signupToken,
           });
           navigate("/auth/onboarding", { replace: true });
         } else if ("member" in data) {
-          tokenStorage.setTokens({
+          await tokenStorage.setTokens({
             accessToken: data.accessToken,
             signupToken: null,
           });

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,3 +1,6 @@
+import { SecureStoragePlugin } from "capacitor-secure-storage-plugin";
+import { isNativeApp } from "./auth/envUtils";
+
 export type AuthTokens = {
   accessToken: string | null;
   signupToken: string | null;
@@ -6,33 +9,90 @@ export type AuthTokens = {
 const ACCESS_KEY = "accessToken";
 const SIGNUP_KEY = "signupToken";
 
-// refreshToken은 서버가 httpOnly 쿠키로 관리하므로 클라이언트에 저장 X
 export const tokenStorage = {
-  getAccessToken(): string | null {
+  // Access Token 가져오기
+  async getAccessToken(): Promise<string | null> {
+    if (isNativeApp()) {
+      try {
+        const { value } = await SecureStoragePlugin.get({ key: ACCESS_KEY });
+        return value;
+      } catch {
+        return null;
+      }
+    }
     return localStorage.getItem(ACCESS_KEY);
   },
 
-  getSignupToken(): string | null {
+  // Signup Token 가져오기
+  async getSignupToken(): Promise<string | null> {
+    if (isNativeApp()) {
+      try {
+        const { value } = await SecureStoragePlugin.get({ key: SIGNUP_KEY });
+        return value;
+      } catch {
+        return null;
+      }
+    }
     return localStorage.getItem(SIGNUP_KEY);
   },
 
-  setTokens(tokens: AuthTokens) {
-    if (tokens.accessToken)
-      localStorage.setItem(ACCESS_KEY, tokens.accessToken);
-    else localStorage.removeItem(ACCESS_KEY);
+  // 토큰 저장하기 (로그인 성공 시)
+  async setTokens(tokens: AuthTokens): Promise<void> {
+    if (isNativeApp()) {
+      if (tokens.accessToken)
+        await SecureStoragePlugin.set({
+          key: ACCESS_KEY,
+          value: tokens.accessToken,
+        });
+      else await SecureStoragePlugin.remove({ key: ACCESS_KEY });
 
-    if (tokens.signupToken)
-      localStorage.setItem(SIGNUP_KEY, tokens.signupToken);
-    else localStorage.removeItem(SIGNUP_KEY);
+      if (tokens.signupToken)
+        await SecureStoragePlugin.set({
+          key: SIGNUP_KEY,
+          value: tokens.signupToken,
+        });
+      else await SecureStoragePlugin.remove({ key: SIGNUP_KEY });
+
+      // refreshToken 저장 로직 삭제!
+    } else {
+      if (tokens.accessToken)
+        localStorage.setItem(ACCESS_KEY, tokens.accessToken);
+      else localStorage.removeItem(ACCESS_KEY);
+
+      if (tokens.signupToken)
+        localStorage.setItem(SIGNUP_KEY, tokens.signupToken);
+      else localStorage.removeItem(SIGNUP_KEY);
+    }
   },
 
-  setSignupToken(token: string | null) {
-    if (token) localStorage.setItem(SIGNUP_KEY, token);
-    else localStorage.removeItem(SIGNUP_KEY);
+  // 단일 토큰 세팅
+  async setSignupToken(token: string | null): Promise<void> {
+    if (isNativeApp()) {
+      if (token)
+        await SecureStoragePlugin.set({ key: SIGNUP_KEY, value: token });
+      else await SecureStoragePlugin.remove({ key: SIGNUP_KEY });
+    } else {
+      if (token) localStorage.setItem(SIGNUP_KEY, token);
+      else localStorage.removeItem(SIGNUP_KEY);
+    }
   },
 
-  clear() {
-    localStorage.removeItem(ACCESS_KEY);
-    localStorage.removeItem(SIGNUP_KEY);
+  // 토큰 초기화 (로그아웃 시)
+  async clear(): Promise<void> {
+    if (isNativeApp()) {
+      try {
+        await SecureStoragePlugin.remove({ key: ACCESS_KEY });
+      } catch {
+        // ESLint 통과를 위한 주석 (에러 무시)
+      }
+      try {
+        await SecureStoragePlugin.remove({ key: SIGNUP_KEY });
+      } catch {
+        // ESLint 통과를 위한 주석 (에러 무시)
+      }
+    } else {
+      localStorage.removeItem(ACCESS_KEY);
+      localStorage.removeItem(SIGNUP_KEY);
+    }
   },
 };


### PR DESCRIPTION
🔀 Pull Request Title
refactor: iOS 애플 로그인 네이티브 연동 및 스플래시 자동 로그인 구현

Closes #300 (이슈 번호가 있다면 적어주세요!)

🎞️ 주요 코드 설명 


📌 PR 설명
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- [x] 애플 로그인 로직 구현: Capacitor 플러그인(예: @capacitor-community/apple-sign-in) 연동

- [x] 리프레시 토큰 및 로그인 유지 로직 적용: 자동 로그인을 위한 리프레시 토큰 관리 및 인터셉터를 통한 액세스 토큰 자동 재발급 로직 구현/검증

- [x] 스플래시 애니메이션 통일: 앱, 웹 스플래시 애니메이션 로직 수정 및 통합

📷 스크린샷


💬 Comment
참고사항: iOS 앱(네이티브) 환경에서는 인증을 직접 처리하므로 Service ID나 리다이렉트 URI(Return URI)를 설정할 필요가 없음.