### PR TITLE
[FIX] Capacitor 네이티브 플러그인 sync 누락 수정 (secure-storage/splash-screen/apple-sign-in)

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,7 +9,10 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-apple-sign-in')
     implementation project(':capacitor-app')
+    implementation project(':capacitor-splash-screen')
+    implementation project(':capacitor-secure-storage-plugin')
     implementation project(':capacitor3-kakao-login')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,8 +2,17 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/.pnpm/@capacitor+android@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-apple-sign-in'
+project(':capacitor-community-apple-sign-in').projectDir = new File('../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in/android')
+
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app/android')
+
+include ':capacitor-splash-screen'
+project(':capacitor-splash-screen').projectDir = new File('../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen/android')
+
+include ':capacitor-secure-storage-plugin'
+project(':capacitor-secure-storage-plugin').projectDir = new File('../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin/android')
 
 include ':capacitor3-kakao-login'
 project(':capacitor3-kakao-login').projectDir = new File('../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login/android')

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -10,7 +10,10 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios'
+  pod 'CapacitorCommunityAppleSignIn', :path => '../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in'
   pod 'CapacitorApp', :path => '../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app'
+  pod 'CapacitorSplashScreen', :path => '../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen'
+  pod 'CapacitorSecureStoragePlugin', :path => '../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin'
   pod 'Capacitor3KakaoLogin', :path => '../../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login'
 end
 

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -12,7 +12,14 @@ PODS:
     - KakaoSDKUser
   - CapacitorApp (8.1.0):
     - Capacitor
+  - CapacitorCommunityAppleSignIn (7.1.0):
+    - Capacitor
   - CapacitorCordova (8.3.4)
+  - CapacitorSecureStoragePlugin (0.13.0):
+    - Capacitor
+    - SwiftKeychainWrapper
+  - CapacitorSplashScreen (8.0.1):
+    - Capacitor
   - KakaoSDKAuth (2.22.7):
     - KakaoSDKCommon (= 2.22.7)
   - KakaoSDKCommon (2.22.7):
@@ -32,12 +39,16 @@ PODS:
     - KakaoSDKCommon/Common (= 2.22.7)
   - KakaoSDKUser (2.22.7):
     - KakaoSDKAuth (= 2.22.7)
+  - SwiftKeychainWrapper (4.0.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios`)"
   - "Capacitor3KakaoLogin (from `../../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login`)"
   - "CapacitorApp (from `../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app`)"
+  - "CapacitorCommunityAppleSignIn (from `../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in`)"
   - "CapacitorCordova (from `../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios`)"
+  - "CapacitorSecureStoragePlugin (from `../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin`)"
+  - "CapacitorSplashScreen (from `../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen`)"
 
 SPEC REPOS:
   trunk:
@@ -48,6 +59,7 @@ SPEC REPOS:
     - KakaoSDKTalk
     - KakaoSDKTemplate
     - KakaoSDKUser
+    - SwiftKeychainWrapper
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -56,22 +68,32 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login"
   CapacitorApp:
     :path: "../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app"
+  CapacitorCommunityAppleSignIn:
+    :path: "../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in"
   CapacitorCordova:
     :path: "../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios"
+  CapacitorSecureStoragePlugin:
+    :path: "../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin"
+  CapacitorSplashScreen:
+    :path: "../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen"
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   Capacitor: d13cad5fa09155679672808cc4ca9fbc2997e1b4
   Capacitor3KakaoLogin: c48437e94bf1920730caeed35f35695fad783eb6
   CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
+  CapacitorCommunityAppleSignIn: 271cb2860576fd2961508bbfa7a82117d93eadca
   CapacitorCordova: c07921bdcfec6f691bae22274446b4d606ebf6a4
+  CapacitorSecureStoragePlugin: d083ff28d9ba5bc74924b9bcf9754ea605016b63
+  CapacitorSplashScreen: 4b46c72298db552b3c57ce021ef028b6dc7f1fa7
   KakaoSDKAuth: 45204252ff7c379c0f86c5573f97ec36885afca0
   KakaoSDKCommon: 132164a6bac8bcd3a4346d3bf777f34f8f39fdca
   KakaoSDKShare: 01c60c3d5394479429a51ef14ea78d3e72f48af0
   KakaoSDKTalk: a0c41d014cfda872ea9adae41bcaf7720a002785
   KakaoSDKTemplate: b11ecf08777198ffafd184201baf93de476ddb84
   KakaoSDKUser: 4c9cf1da78710d19d0b2c2dd32d1a44c544cdfa4
+  SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: afbadddb1aabd017c6807382986063d1d44d3a88
+PODFILE CHECKSUM: d9818cac3cf75db0a74d25b03c96371218593d22
 
 COCOAPODS: 1.16.2

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -9,6 +9,16 @@ export type AuthTokens = {
 const ACCESS_KEY = "accessToken";
 const SIGNUP_KEY = "signupToken";
 
+// SecureStoragePlugin.remove 는 키가 없으면 reject 한다.
+// 토큰을 비우는 경우(저장된 적 없는 키 삭제)는 정상 흐름이므로 reject 를 무시한다.
+async function removeNativeKey(key: string): Promise<void> {
+  try {
+    await SecureStoragePlugin.remove({ key });
+  } catch {
+    // 키가 존재하지 않으면 무시
+  }
+}
+
 export const tokenStorage = {
   // Access Token 가져오기
   async getAccessToken(): Promise<string | null> {
@@ -44,14 +54,14 @@ export const tokenStorage = {
           key: ACCESS_KEY,
           value: tokens.accessToken,
         });
-      else await SecureStoragePlugin.remove({ key: ACCESS_KEY });
+      else await removeNativeKey(ACCESS_KEY);
 
       if (tokens.signupToken)
         await SecureStoragePlugin.set({
           key: SIGNUP_KEY,
           value: tokens.signupToken,
         });
-      else await SecureStoragePlugin.remove({ key: SIGNUP_KEY });
+      else await removeNativeKey(SIGNUP_KEY);
 
       // refreshToken 저장 로직 삭제!
     } else {
@@ -70,7 +80,7 @@ export const tokenStorage = {
     if (isNativeApp()) {
       if (token)
         await SecureStoragePlugin.set({ key: SIGNUP_KEY, value: token });
-      else await SecureStoragePlugin.remove({ key: SIGNUP_KEY });
+      else await removeNativeKey(SIGNUP_KEY);
     } else {
       if (token) localStorage.setItem(SIGNUP_KEY, token);
       else localStorage.removeItem(SIGNUP_KEY);


### PR DESCRIPTION
## Summary
네이티브 앱(안드/iOS)에서 카카오 로그인 성공(서버 200) 직후 메인으로 진입하지 못하고 멈추는 문제 수정.

`capacitor-secure-storage-plugin`, `@capacitor/splash-screen`, `@capacitor-community/apple-sign-in` 이 package.json 에는 선언돼 있으나 네이티브(android/ios)에는 cap sync 누락으로 미등록 상태였음.

→ 런타임에 SecureStoragePlugin.set/get 호출이 not implemented 로 실패 → tokenStorage.setTokens throw → handleKakaoLogin catch 가 삼켜 navigate 미발생 → 무한 로딩/메인 미진입.

- 로컬(웹 pnpm dev)은 isNativeApp()=false 라 localStorage 경로 → 정상. 네이티브 빌드에서만 재현.
- 백엔드 정상(/auth/social/login 200, prod 로그 에러 0건).

## Changes
- pnpm cap:sync 로 네이티브 플러그인 등록 파일 재생성
  - android/capacitor.settings.gradle, android/app/capacitor.build.gradle: secure-storage/splash-screen/apple-sign-in include 추가
  - ios/App/Podfile, Podfile.lock: 동일 플러그인 pod 추가
- assembleDebug BUILD SUCCESSFUL 로 컴파일/링크 검증

## Type of Change
- [x] Bug fix (non-breaking)

## Related Issues
- 카카오 로그인 후 메인 미진입 / 무한 로딩 (QA 블로커)

## Checklist
- [x] cap sync 후 플러그인 5종 인식 확인
- [x] Android assembleDebug BUILD SUCCESSFUL
- [ ] 릴리스 서명 빌드 후 실기기 카카오 로그인 검증
- [ ] 재발 방지: CI 에 cap sync 추가 검토