### PR TITLE
[REFACTOR] V2 1차 QA 이슈 대응

### DIFF
--- a/src/apis/mainPage/mainPage.api.ts
+++ b/src/apis/mainPage/mainPage.api.ts
@@ -8,7 +8,7 @@ export interface Lab {
 }
 
 export interface CommunityPost {
-  postId: number;
+  postId: string;
   image: {
     imageUrl: string;
     width: number;
@@ -66,7 +66,7 @@ export const fetchCommunityPosts = async (): Promise<CommunityPost[]> => {
 };
 
 /** 게시글 좋아요 */
-export const likePost = async (postId: number): Promise<void> => {
+export const likePost = async (postId: string): Promise<void> => {
   try {
     await axiosInstance.post(`/posts/${postId}/likes`);
   } catch (error) {
@@ -78,6 +78,6 @@ export const likePost = async (postId: number): Promise<void> => {
 };
 
 /** 게시글 좋아요 취소 */
-export const unlikePost = async (postId: number): Promise<void> => {
+export const unlikePost = async (postId: string): Promise<void> => {
   await axiosInstance.delete(`/posts/${postId}/likes`);
 };

--- a/src/apis/my/notices/getNoticeList.ts
+++ b/src/apis/my/notices/getNoticeList.ts
@@ -19,7 +19,7 @@ export const getNoticeList = async (type: NoticeType, page = 0, size = 10) => {
 };
 
 // Path Variable로 noticeId를 전달받아 요청
-export const getNoticeDetail = async (noticeId: number) => {
+export const getNoticeDetail = async (noticeId: string) => {
   const { data } = await axiosInstance.get<NoticeDetailResponse>(
     `/notices/${noticeId}`,
   );

--- a/src/apis/photoRestoration/restoration.api.ts
+++ b/src/apis/photoRestoration/restoration.api.ts
@@ -9,16 +9,16 @@ import type { PresignedUrlIssueResDto } from "@/types/file/presignedUrl";
 export type PresignedUrlResponse = ApiResponse<PresignedUrlIssueResDto>;
 
 type JwtPayload = {
-  id?: number;
-  memberId?: number;
-  sub?: string | number;
+  id?: string;
+  memberId?: string;
+  sub?: string;
 };
 
-export function getMemberIdFromToken(token: string): number {
+export function getMemberIdFromToken(token: string): string {
   const decoded = jwtDecode<JwtPayload>(token);
-  const memberId = Number(decoded.id ?? decoded.memberId ?? decoded.sub);
+  const memberId = decoded.id ?? decoded.memberId ?? decoded.sub;
 
-  if (!Number.isInteger(memberId) || memberId <= 0) {
+  if (!memberId) {
     throw new Error("No valid memberId found in token");
   }
 
@@ -84,7 +84,7 @@ export async function uploadToGCS(
 }
 
 export interface RequestRestorationResponseData {
-  id: number;
+  id: string;
 }
 
 export type RestorationStatus =
@@ -94,7 +94,7 @@ export type RestorationStatus =
   | "FAILED";
 
 export interface RestorationStatusData {
-  id: number;
+  id: string;
   originalUrl: string;
   restoredUrl: string | null;
   restoredWidth: number | null;
@@ -139,7 +139,7 @@ export async function requestRestoration(
 
 // 4. 상태 조회 (GET) - creditUsed 포함
 export async function getRestorationStatus(
-  id: number,
+  id: string,
 ): Promise<ApiResponse<RestorationStatusData>> {
   const response = await axiosInstance.get<ApiResponse<RestorationStatusData>>(
     `/restorations/${id}`,

--- a/src/apis/photoRestoration/restoration.api.ts
+++ b/src/apis/photoRestoration/restoration.api.ts
@@ -16,13 +16,13 @@ type JwtPayload = {
 
 export function getMemberIdFromToken(token: string): string {
   const decoded = jwtDecode<JwtPayload>(token);
-  const memberId = decoded.id ?? decoded.memberId ?? decoded.sub;
+  const rawMemberId = decoded.id ?? decoded.memberId ?? decoded.sub;
 
-  if (!memberId) {
+  if (!rawMemberId) {
     throw new Error("No valid memberId found in token");
   }
 
-  return memberId;
+  return String(rawMemberId);
 }
 
 // 1. Presigned URL 발급 요청

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -49,7 +49,7 @@ export const TabBar = () => {
 
   const { requireAuth, requireAuthNavigate } = useRequireAuth();
   const user = useAuthStore((s) => s.user);
-  const isAuthed = Boolean(user && user.memberId > 0);
+  const isAuthed = Boolean(user?.memberId);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/mainPage/ComunityGallarySection/CommunityGallerySectionCard.tsx
+++ b/src/components/mainPage/ComunityGallarySection/CommunityGallerySectionCard.tsx
@@ -13,12 +13,12 @@ interface CommunityGallerySectionCardProps {
 
 const COMMUNITY_PREVIEW_QK = ["community", "posts", "preview"] as const;
 
-type LikeVars = { postId: number; nextLiked: boolean };
+type LikeVars = { postId: string; nextLiked: boolean };
 type LikeCtx = { previous?: CommunityPost[] };
 
 function patchCommunityPreviewPost(
   prev: CommunityPost[] | undefined,
-  postId: number,
+  postId: string,
   patch: (p: CommunityPost) => CommunityPost,
 ) {
   if (!prev) return prev;

--- a/src/components/mainPage/PromotionBanner.tsx
+++ b/src/components/mainPage/PromotionBanner.tsx
@@ -19,7 +19,7 @@ export default function PromotionBanner() {
   const navigate = useNavigate();
   const { requireAuth } = useRequireAuth();
   const user = useAuthStore((s) => s.user);
-  const isAuthed = Boolean(user && user.memberId > 0);
+  const isAuthed = Boolean(user?.memberId);
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);

--- a/src/hooks/my/notices/useGetNoticeDetail.ts
+++ b/src/hooks/my/notices/useGetNoticeDetail.ts
@@ -1,12 +1,12 @@
 import { getNoticeDetail } from "@/apis/my";
 import { useQuery } from "@tanstack/react-query";
 
-export const useNoticeDetail = (noticeId: number | null) => {
+export const useNoticeDetail = (noticeId: string | null) => {
   return useQuery({
     // noticeId가 바뀔 때마다 새 데이터를 캐싱 및 조회하도록 설정
     queryKey: ["noticeDetail", noticeId],
     queryFn: () => getNoticeDetail(noticeId!),
-    // 방어 코드: id가 유효한 숫자로 넘어왔을 때만 API 요청을 보냄
-    enabled: typeof noticeId === "number" && !isNaN(noticeId),
+    // 방어 코드: id가 유효한 값으로 넘어왔을 때만 API 요청을 보냄
+    enabled: typeof noticeId === "string" && noticeId.length > 0,
   });
 };

--- a/src/hooks/my/notices/useGetNoticeDetail.ts
+++ b/src/hooks/my/notices/useGetNoticeDetail.ts
@@ -7,6 +7,6 @@ export const useNoticeDetail = (noticeId: string | null) => {
     queryKey: ["noticeDetail", noticeId],
     queryFn: () => getNoticeDetail(noticeId!),
     // 방어 코드: id가 유효한 값으로 넘어왔을 때만 API 요청을 보냄
-    enabled: typeof noticeId === "string" && noticeId.length > 0,
+    enabled: typeof noticeId === "string" && noticeId.trim().length > 0,
   });
 };

--- a/src/hooks/photoFeed/posts/useCreatePostWithUpload.ts
+++ b/src/hooks/photoFeed/posts/useCreatePostWithUpload.ts
@@ -10,7 +10,7 @@ type SubmitArgs = {
   content: string;
   files: File[];
   imageMetas: ImageMeta[];
-  memberId?: number | null;
+  memberId?: string | null;
 
   labId?: string;
   isSelfDeveloped: boolean;

--- a/src/hooks/photoRestoration/useRestoration.ts
+++ b/src/hooks/photoRestoration/useRestoration.ts
@@ -86,7 +86,7 @@ export const useRestoration = () => {
     }
   };
 
-  const pollStatus = (id: number) => {
+  const pollStatus = (id: string) => {
     const MAX_RETRIES = 90;
     let count = 0;
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -7,6 +7,7 @@ import { useAppleLogin, useLoginIntroUi } from "@/hooks/auth/login";
 import { useAuthStore } from "@/store/useAuth.store";
 import { Capacitor3KakaoLogin } from "capacitor3-kakao-login";
 import { isNativeApp } from "@/utils/auth/envUtils";
+import { isAndroidApp } from "@/utils/platform";
 import { oauth } from "@/apis/auth";
 import { tokenStorage } from "@/utils/tokenStorage";
 import { consumeRedirectAfterLogin } from "../demoDay/redirectAfterLogin";
@@ -259,7 +260,9 @@ export function LoginPage() {
             className={`mx-auto max-w-sm ${ui.footerAnim}`}
           >
             <div className="flex flex-col gap-2">
-              <AppleButton onClick={apple.login} disabled={apple.isPending} />
+              {!isAndroidApp() && (
+                <AppleButton onClick={apple.login} disabled={apple.isPending} />
+              )}
               <KakaoButton onClick={handleKakaoLogin} />
             </div>
 

--- a/src/pages/demoDay/DemoDayPage.tsx
+++ b/src/pages/demoDay/DemoDayPage.tsx
@@ -46,7 +46,7 @@ export default function DemoDayPage() {
       const image = DEMO_IMAGES[index];
       if (!image) return;
 
-      const isAuthed = Boolean(user && user.memberId > 0);
+      const isAuthed = Boolean(user?.memberId);
 
       if (isAuthed) {
         navigate("/restore/editor", {

--- a/src/pages/mypage/DeviceRegisterPage.tsx
+++ b/src/pages/mypage/DeviceRegisterPage.tsx
@@ -54,10 +54,13 @@ export function DeviceRegisterPage() {
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
 
   // 부모(Layout)가 내려준 setCustomOnBack 가져오기
-  const { setCustomOnBack } = useOutletContext<MyPageOutletContext>();
+  const context = useOutletContext<MyPageOutletContext | null>();
+  const setCustomOnBack = context?.setCustomOnBack;
 
   // tep이 변경될 때마다 뒤로가기 동작을 가로채거나 원상복구
   useEffect(() => {
+    if (!setCustomOnBack) return;
+
     if (step === "REGISTER") {
       // 등록 뷰일 때는 뒤로가기 누르면 다이얼로그 오픈!
       setCustomOnBack(() => () => setIsCancelDialogOpen(true));

--- a/src/pages/mypage/DeviceRegisterPage.tsx
+++ b/src/pages/mypage/DeviceRegisterPage.tsx
@@ -448,7 +448,7 @@ function RegisterView({ initialData, onSubmit }: RegisterViewProps) {
       />
 
       <BottomSheet open={isBottomSheetOpen} onClose={closeBottomSheet}>
-        <div className="flex h-[60vh] flex-col gap-6 px-4 pt-4">
+        <div className="flex h-full flex-col gap-6 px-4 pt-4">
           <SearchBar
             value={searchValue}
             onChange={setSearchValue}

--- a/src/pages/mypage/edit-info/EditInfoPage.tsx
+++ b/src/pages/mypage/edit-info/EditInfoPage.tsx
@@ -151,7 +151,7 @@ export function EditInfoPage() {
     if (!me) throw new Error("내 정보가 아직 없어요.");
 
     const memberId = me.member?.memberId;
-    if (typeof memberId !== "number")
+    if (typeof memberId !== "string" || memberId.length === 0)
       throw new Error("memberId를 찾을 수 없어요.");
 
     setIsUploadingProfile(true);
@@ -209,7 +209,15 @@ export function EditInfoPage() {
     try {
       await uploadProfileImage(picked);
     } catch (err) {
-      console.log(err);
+      console.error(err);
+      setError("사진 업로드에 실패했어요. 다시 시도해 주세요.");
+
+      // 업로드 실패 시 낙관적으로 보여준 미리보기를 되돌림
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+      setObjectUrl(null);
     }
   };
 

--- a/src/pages/mypage/inquiry/InquiryPage.tsx
+++ b/src/pages/mypage/inquiry/InquiryPage.tsx
@@ -12,12 +12,28 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { useInfiniteScroll } from "@/hooks/common/useInfiniteScroll";
 import { useInquiriesInfinite } from "@/hooks/my";
 import { useCreateInquiry } from "@/hooks/my/inquiries/useCreateInquiry";
+import { useOutletContext } from "react-router";
+import type { MyPageOutletContext } from "@/layouts/MyPageLayout";
 
 // 스텝 타입 정의
 type Step = "LIST" | "CREATE";
 
 export function InquiryPage() {
   const [step, setStep] = useState<Step>("LIST");
+
+  // 부모(Layout)가 내려준 setCustomOnBack 가져오기
+  const { setCustomOnBack } = useOutletContext<MyPageOutletContext>();
+
+  // step이 CREATE일 때는 헤더 뒤로가기가 라우터 히스토리가 아닌 LIST로 돌아가게 함
+  useEffect(() => {
+    if (step === "CREATE") {
+      setCustomOnBack(() => () => setStep("LIST"));
+    } else {
+      setCustomOnBack(null);
+    }
+
+    return () => setCustomOnBack(null);
+  }, [step, setCustomOnBack]);
 
   return (
     <div className="flex h-full flex-1 flex-col">

--- a/src/pages/mypage/inquiry/InquiryPage.tsx
+++ b/src/pages/mypage/inquiry/InquiryPage.tsx
@@ -22,10 +22,13 @@ export function InquiryPage() {
   const [step, setStep] = useState<Step>("LIST");
 
   // 부모(Layout)가 내려준 setCustomOnBack 가져오기
-  const { setCustomOnBack } = useOutletContext<MyPageOutletContext>();
+  const context = useOutletContext<MyPageOutletContext | null>();
+  const setCustomOnBack = context?.setCustomOnBack;
 
   // step이 CREATE일 때는 헤더 뒤로가기가 라우터 히스토리가 아닌 LIST로 돌아가게 함
   useEffect(() => {
+    if (!setCustomOnBack) return;
+
     if (step === "CREATE") {
       setCustomOnBack(() => () => setStep("LIST"));
     } else {

--- a/src/pages/mypage/notice/EventNoticePage.tsx
+++ b/src/pages/mypage/notice/EventNoticePage.tsx
@@ -6,9 +6,9 @@ import { useSearchParams } from "react-router";
 export function EventNoticePage() {
   const [searchParams] = useSearchParams();
 
-  // URL에서 ?id=... 값을 읽어와 숫자로 변환 (예: "?id=1" -> 1)
+  // URL에서 ?id=... 값을 읽어옴 (TSID 문자열)
   const idParam = searchParams.get("id");
-  const noticeId = idParam ? Number(idParam) : null;
+  const noticeId = idParam || null;
 
   // API 호출
   const { data: response, isLoading, isError } = useNoticeDetail(noticeId);

--- a/src/pages/mypage/notice/PolicyNoticePage.tsx
+++ b/src/pages/mypage/notice/PolicyNoticePage.tsx
@@ -6,9 +6,9 @@ import { useSearchParams } from "react-router";
 export function PolicyNoticePage() {
   const [searchParams] = useSearchParams();
 
-  // URL에서 ?id=... 값을 읽어와 숫자로 변환 (예: "?id=1" -> 1)
+  // URL에서 ?id=... 값을 읽어옴 (TSID 문자열)
   const idParam = searchParams.get("id");
-  const noticeId = idParam ? Number(idParam) : null;
+  const noticeId = idParam || null;
 
   // API 호출
   const { data: response, isLoading, isError } = useNoticeDetail(noticeId);

--- a/src/pages/mypage/notice/SimpleNoticePage.tsx
+++ b/src/pages/mypage/notice/SimpleNoticePage.tsx
@@ -6,9 +6,9 @@ import { useSearchParams } from "react-router";
 export function SimpleNoticePage() {
   const [searchParams] = useSearchParams();
 
-  // URL에서 ?id=... 값을 읽어와 숫자로 변환 (예: "?id=1" -> 1)
+  // URL에서 ?id=... 값을 읽어옴 (TSID 문자열)
   const idParam = searchParams.get("id");
-  const noticeId = idParam ? Number(idParam) : null;
+  const noticeId = idParam || null;
 
   //API 호출
   const { data: response, isLoading, isError } = useNoticeDetail(noticeId);

--- a/src/pages/mypage/tab/MyPostPage.tsx
+++ b/src/pages/mypage/tab/MyPostPage.tsx
@@ -60,7 +60,7 @@ export function MyPostPage() {
   const posts: Post[] = useMemo(
     () =>
       previews.map((p) => ({
-        id: Number(p.postId),
+        id: p.postId,
         src: p.image.imageUrl,
         title: p.title,
         likes: p.likeCount,

--- a/src/pages/photoFeed/PostPage.tsx
+++ b/src/pages/photoFeed/PostPage.tsx
@@ -104,8 +104,11 @@ export default function PostPage() {
     }
     if (isPostError)
       return (
-        <div className="pointer-events-none fixed inset-0 flex items-center justify-center">
-          <p className="text-red-400">불러오기에 실패했어요.</p>
+        <div className="flex h-full flex-col">
+          <Header title="" showBack onBack={handleGoBack} />
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-red-400">불러오기에 실패했어요.</p>
+          </div>
         </div>
       );
     if (!postDetail) return <EmptyView content="게시글 정보가 없습니다." />;

--- a/src/store/useAuth.store.ts
+++ b/src/store/useAuth.store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type User = {
-  memberId: number;
+  memberId: string;
   nickname: string;
 };
 
@@ -13,7 +13,7 @@ type AuthState = {
   clearUser: () => void;
 
   setNickname: (nickname: string) => void;
-  setMemberId: (memberId: number) => void;
+  setMemberId: (memberId: string) => void;
 };
 
 const AUTH_STORAGE_KEY = "finders-auth";
@@ -53,6 +53,15 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "finders-auth",
       partialize: (state) => ({ user: state.user }),
+      version: 1,
+      // memberId가 number(구 형식)로 저장된 세션은 폐기 (TSID string 전환)
+      migrate: (persistedState) => {
+        const state = persistedState as { user: User | null } | undefined;
+        if (typeof state?.user?.memberId === "number") {
+          return { user: null };
+        }
+        return state;
+      },
     },
   ),
 );

--- a/src/types/auth/oAuth.ts
+++ b/src/types/auth/oAuth.ts
@@ -31,7 +31,7 @@ export type SocialLoginSignupRequired = {
 export type SocialLoginSuccess = {
   accessToken: string;
   member: {
-    id: number;
+    id: string;
     nickname: string;
   };
 };

--- a/src/types/auth/signUp.ts
+++ b/src/types/auth/signUp.ts
@@ -10,7 +10,7 @@ export interface SocialSignupCompleteReq {
 export type SocialSignupCompleteData = {
   accessToken: string;
   member: {
-    memberId: number;
+    memberId: string;
     nickname: string;
   };
 };

--- a/src/types/file/presignedUrl.ts
+++ b/src/types/file/presignedUrl.ts
@@ -14,7 +14,7 @@ export type PresignedUploadCategory =
 export type PresignedUrlIssueReqDto = {
   category: PresignedUploadCategory;
   fileName: string;
-  memberId?: number;
+  memberId?: string;
 };
 
 export type PresignedUrlIssueResDto = {

--- a/src/types/mypage/info.ts
+++ b/src/types/mypage/info.ts
@@ -4,7 +4,7 @@ export type Role = "USER" | "OWNER" | "ADMIN";
 export type MemberStatus = "ACTIVE" | "INACTIVE" | "SUSPENDED" | "DELETED";
 
 export interface MemberDto {
-  memberId: number;
+  memberId: string;
   name: string;
   phone: string;
   role: Role;

--- a/src/types/mypage/inquiry.ts
+++ b/src/types/mypage/inquiry.ts
@@ -8,7 +8,7 @@ export type InquiryStatus = "PENDING" | "COMPLETED"; // API에는 PENDING으로 
 
 // 개별 문의 아이템 타입
 export interface InquiryItem {
-  id: number;
+  id: string;
   type: InquiryType;
   content: string;
   status: InquiryStatus;

--- a/src/types/mypage/notice.ts
+++ b/src/types/mypage/notice.ts
@@ -3,7 +3,7 @@ export type TabName = "일반공지" | "이벤트 안내" | "약관/정책";
 export type NoticeType = "GENERAL" | "EVENT" | "POLICY";
 
 export interface NoticeItem {
-  id: number;
+  id: string;
   title: string;
   type: NoticeType;
   createdAt: string;

--- a/src/types/mypage/post.ts
+++ b/src/types/mypage/post.ts
@@ -2,7 +2,7 @@ import type { ApiResponse } from "@/types/common/apiResponse";
 import type { PhotoFeedResponse } from "../photoFeed/postPreview";
 
 export type Post = {
-  id: number;
+  id: string;
   src: string;
   title: string;
   date: string;


### PR DESCRIPTION
## 🔀 Pull Request Title

refactor: V2 1차 QA 이슈 대응(#314)

- Closes #314

<br>

## 🎞️ 주요 코드 설명

### 응답 타입 일괄 변경
- API 응답 및 관련 타입 정의에서 number로 되어있던 필드를 string으로 일괄 변경 (`mainPage.api.ts`, `restoration.api.ts`, `auth/oAuth.ts`, `auth/signUp.ts` 등)

### 안드로이드 애플 로그인 버튼 제거
- `LoginPage.tsx`에서 플랫폼이 안드로이드일 경우 애플 로그인 버튼을 노출하지 않도록 분기 처리

### 문의 작성 페이지 라우팅
- `InquiryPage.tsx`에서 문의 작성 완료 후 이동 경로 수정

### 바텀시트 전체화면
- `DeviceRegisterPage.tsx`의 기기 등록 바텀시트를 전체화면으로 사용하도록 수정

### 사진 업로드 에러 처리
- `EditInfoPage.tsx`에서 프로필 사진 업로드 실패 시 에러 처리 로직 보완

### API 에러 시 UI 처리
- `PostPage.tsx`에서 게시글 작성 API 에러 발생 시 에러 UI 노출 처리 추가

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] 응답 타입(number -> string) 일괄 변경
- [x] 안드로이드 환경에서 애플 로그인 버튼 노출 제거
- [x] 문의 작성 페이지 라우팅 경로 변경
- [x] 마이페이지 기기 등록 바텀시트 전체화면으로 수정
- [x] 사진 업로드 에러 처리 보완
- [x] 게시글 작성 API 에러 시 UI 처리 추가
- [x] notice 관련 페이지 타입 검사 적용

<br>

## 📷 스크린샷

<!-- UI 변경 스크린샷 첨부 -->