### PR TITLE
[FIX] 네이티브 애플 로그인 오류 수정 및 dev/prod 빌드 분리

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		71240F2AB801F563F58E31C4 /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 		785C01732FF2604B006FD329 /* Products.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Products.storekit; sourceTree = "<group>"; };
+		78EF470F2FF901EC00A0996C /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 		B0360D5A5E7B1C5A61EFB802 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E47E3B12E0F564B87B144E94 /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
@@ -90,6 +91,7 @@
 		504EC3061FED79650016851F /* App */ = {
 			isa = PBXGroup;
 			children = (
+				78EF470F2FF901EC00A0996C /* App.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				FB000000000000000000B001 /* FindersBillingPlugin.swift */,
@@ -368,6 +370,7 @@
 			baseConfigurationReference = 71240F2AB801F563F58E31C4 /* Pods-App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YC7R5A6449;
@@ -389,6 +392,7 @@
 			baseConfigurationReference = E47E3B12E0F564B87B144E94 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YC7R5A6449;

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -42,13 +42,13 @@ PODS:
   - SwiftKeychainWrapper (4.0.1)
 
 DEPENDENCIES:
-  - "Capacitor (from `../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios`)"
-  - "Capacitor3KakaoLogin (from `../../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login`)"
-  - "CapacitorApp (from `../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app`)"
-  - "CapacitorCommunityAppleSignIn (from `../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in`)"
-  - "CapacitorCordova (from `../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios`)"
-  - "CapacitorSecureStoragePlugin (from `../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin`)"
-  - "CapacitorSplashScreen (from `../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen`)"
+  - "Capacitor (from `../../node_modules/@capacitor/ios`)"
+  - Capacitor3KakaoLogin (from `../../node_modules/capacitor3-kakao-login`)
+  - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
+  - "CapacitorCommunityAppleSignIn (from `../../node_modules/@capacitor-community/apple-sign-in`)"
+  - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - CapacitorSecureStoragePlugin (from `../../node_modules/capacitor-secure-storage-plugin`)
+  - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
 
 SPEC REPOS:
   trunk:
@@ -63,19 +63,19 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Capacitor:
-    :path: "../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios"
+    :path: "../../node_modules/@capacitor/ios"
   Capacitor3KakaoLogin:
-    :path: "../../node_modules/.pnpm/capacitor3-kakao-login@0.8.7_@capacitor+core@8.3.4/node_modules/capacitor3-kakao-login"
+    :path: "../../node_modules/capacitor3-kakao-login"
   CapacitorApp:
-    :path: "../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.3.4/node_modules/@capacitor/app"
+    :path: "../../node_modules/@capacitor/app"
   CapacitorCommunityAppleSignIn:
-    :path: "../../node_modules/.pnpm/@capacitor-community+apple-sign-in@7.1.0_@capacitor+core@8.3.4/node_modules/@capacitor-community/apple-sign-in"
+    :path: "../../node_modules/@capacitor-community/apple-sign-in"
   CapacitorCordova:
-    :path: "../../node_modules/.pnpm/@capacitor+ios@8.3.4_@capacitor+core@8.3.4/node_modules/@capacitor/ios"
+    :path: "../../node_modules/@capacitor/ios"
   CapacitorSecureStoragePlugin:
-    :path: "../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.13.0_@capacitor+core@8.3.4/node_modules/capacitor-secure-storage-plugin"
+    :path: "../../node_modules/capacitor-secure-storage-plugin"
   CapacitorSplashScreen:
-    :path: "../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.3.4/node_modules/@capacitor/splash-screen"
+    :path: "../../node_modules/@capacitor/splash-screen"
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
@@ -94,6 +94,6 @@ SPEC CHECKSUMS:
   KakaoSDKUser: 4c9cf1da78710d19d0b2c2dd32d1a44c544cdfa4
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: d9818cac3cf75db0a74d25b03c96371218593d22
+PODFILE CHECKSUM: 96d4bbc8bae1e1584bb874fb0b7a6eb74f45fd05
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:dev": "tsc -b && vite build --mode development",
     "lint": "eslint . --max-warnings 0 --report-unused-disable-directives",
     "lint:fix": "eslint . --fix",
     "format": "prettier . --write",
@@ -15,6 +16,9 @@
     "cap:sync": "pnpm build && npx cap sync",
     "cap:sync:ios": "pnpm build && npx cap sync ios",
     "cap:sync:android": "pnpm build && npx cap sync android",
+    "cap:sync:dev": "pnpm build:dev && npx cap sync",
+    "cap:sync:ios:dev": "pnpm build:dev && npx cap sync ios",
+    "cap:sync:android:dev": "pnpm build:dev && npx cap sync android",
     "cap:open:ios": "npx cap open ios",
     "cap:open:android": "npx cap open android"
   },


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: 네이티브 애플 로그인 오류 수정 및 dev/prod 빌드 분리

- Closes #321 

<br>

## 🎞️ 주요 코드 설명 

### `Sign In with Apple capability 추가`
- `ASAuthorizationError 1000` 원인: capability 누락
- `App.entitlements`에 `com.apple.developer.applesignin` (Default) 추가
- `project.pbxproj` Debug/Release `CODE_SIGN_ENTITLEMENTS` 연결

### `dev/prod 빌드 스크립트 분리`
- `.env.local` → `.env.development.local` 리네임 (dev 환경변수 production 빌드 혼입 방지)
- 추가 스크립트: `build:dev` / `cap:sync:dev` / `cap:sync:ios:dev` / `cap:sync:android:dev`
- 기본 `build`/`cap:sync:*` → production, `:dev` 계열 → development

### `Podfile.lock 경로 정정`
- pnpm isolated 모드에서 `cap sync` 실행 → `.pnpm` 해시 경로가 lock에 기록됨
- hoisted 레이아웃 재설치 후 sync → `node_modules` 직접 경로로 복원 (#306 `node-linker=hoisted` 기준)

<br>

## 📌 PR 설명

- [x] Sign In with Apple capability 추가 → `ASAuthorizationError 1000` 해결
- [x] dev/prod 빌드 스크립트 분리 → 환경변수 혼입 방지
- [x] Podfile.lock pnpm 해시 경로 → hoisted 경로 정정

<br>
