### PR TITLE
fix: 마이페이지 문의 유형/상태 enum을 BE 계약과 일치 (#326)

### DIFF
--- a/src/components/mypage/inquiry/InquiryListItem.tsx
+++ b/src/components/mypage/inquiry/InquiryListItem.tsx
@@ -51,19 +51,19 @@ export function InquiryListItem({ item }: InquiryListItemProps) {
       <div className="mt-3 flex items-center gap-2">
         <span
           className={`flex h-[1.375rem] items-center justify-center rounded px-1.5 text-[0.75rem] font-medium ${
-            item.status === "ANSWERED"
+            item.status !== "PENDING"
               ? "bg-orange-450 text-neutral-100"
               : "bg-neutral-800 text-neutral-200"
           }`}
         >
-          {item.status === "ANSWERED" ? "답변 완료" : "답변 대기"}
+          {item.status !== "PENDING" ? "답변 완료" : "답변 대기"}
         </span>
         <span className="text-[0.875rem] text-neutral-300">{date}</span>
       </div>
 
       {/* 4. 답변 박스: 펼쳐져 있고, 답변이 완료된 상태일 때만 노출 */}
       {isExpanded &&
-        item.status === "ANSWERED" &&
+        item.status !== "PENDING" &&
         item.hasReply &&
         item.replyContent && (
           <div className="bg-neutral-850 mt-4 flex flex-col rounded-lg p-4">

--- a/src/components/mypage/inquiry/InquiryListItem.tsx
+++ b/src/components/mypage/inquiry/InquiryListItem.tsx
@@ -6,7 +6,7 @@ import type { InquiryItem, InquiryType } from "@/types/mypage/inquiry";
 // 문의 유형 영문을 한글 라벨로 변환하는 매핑 객체
 const INQUIRY_TYPE_LABEL: Record<InquiryType, string> = {
   SERVICE_ERROR: "서비스 이용 오류",
-  ACCOUNT_INFO: "회원정보/정보변경",
+  MEMBER_INFO: "회원정보/정보변경",
   PROMOTION: "프로모션/크레딧",
   PAYMENT: "결제",
 };
@@ -51,19 +51,19 @@ export function InquiryListItem({ item }: InquiryListItemProps) {
       <div className="mt-3 flex items-center gap-2">
         <span
           className={`flex h-[1.375rem] items-center justify-center rounded px-1.5 text-[0.75rem] font-medium ${
-            item.status === "COMPLETED"
+            item.status === "ANSWERED"
               ? "bg-orange-450 text-neutral-100"
               : "bg-neutral-800 text-neutral-200"
           }`}
         >
-          {item.status === "COMPLETED" ? "답변 완료" : "답변 대기"}
+          {item.status === "ANSWERED" ? "답변 완료" : "답변 대기"}
         </span>
         <span className="text-[0.875rem] text-neutral-300">{date}</span>
       </div>
 
       {/* 4. 답변 박스: 펼쳐져 있고, 답변이 완료된 상태일 때만 노출 */}
       {isExpanded &&
-        item.status === "COMPLETED" &&
+        item.status === "ANSWERED" &&
         item.hasReply &&
         item.replyContent && (
           <div className="bg-neutral-850 mt-4 flex flex-col rounded-lg p-4">

--- a/src/types/mypage/inquiry.ts
+++ b/src/types/mypage/inquiry.ts
@@ -1,10 +1,10 @@
 // 문의 유형 및 상태 Enum
 export type InquiryType =
   | "SERVICE_ERROR"
-  | "ACCOUNT_INFO"
+  | "MEMBER_INFO"
   | "PROMOTION"
   | "PAYMENT";
-export type InquiryStatus = "PENDING" | "COMPLETED"; // API에는 PENDING으로 명시됨
+export type InquiryStatus = "PENDING" | "ANSWERED" | "CLOSED"; // BE InquiryStatus enum과 일치
 
 // 개별 문의 아이템 타입
 export interface InquiryItem {
@@ -16,7 +16,7 @@ export interface InquiryItem {
   createdAt: string;
   hasReply: boolean;
 
-  // 답변이 완료(COMPLETED)되었을 경우를 위한 옵셔널 필드
+  // 답변이 완료(ANSWERED)되었을 경우를 위한 옵셔널 필드
   replyContent?: string;
   replyCreatedAt?: string;
 }
@@ -44,7 +44,7 @@ export type InquiryOption = {
 // 4가지 고정 옵션 데이터
 export const INQUIRY_OPTIONS: InquiryOption[] = [
   { label: "서비스 이용 오류", value: "SERVICE_ERROR" },
-  { label: "회원정보/정보변경", value: "ACCOUNT_INFO" },
+  { label: "회원정보/정보변경", value: "MEMBER_INFO" },
   { label: "프로모션/크레딧", value: "PROMOTION" },
   { label: "결제", value: "PAYMENT" },
 ];


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: 마이페이지 문의 유형/상태 enum을 BE 계약과 일치 (#326)

- Closes #326

<br>

## 🎞️ 주요 코드 설명

### 1) 문의 유형 `ACCOUNT_INFO` → `MEMBER_INFO`

- BE `InquiryType` enum은 `SERVICE_ERROR / MEMBER_INFO / PROMOTION / PAYMENT`만 허용. FE가 `회원정보/정보변경`을 `ACCOUNT_INFO`로 전송해 문의 생성 시 400(`Cannot deserialize InquiryType`) 발생하던 것을 수정.
- `src/types/mypage/inquiry.ts`: `InquiryType` 유니온 + `INQUIRY_OPTIONS` value
- `src/components/mypage/inquiry/InquiryListItem.tsx`: `INQUIRY_TYPE_LABEL` 키

### 2) 답변 상태 `COMPLETED` → `ANSWERED`

- BE는 `PENDING / ANSWERED / CLOSED`를 반환하는데 FE가 `COMPLETED`로 비교해 "답변 완료" 뱃지·답변 내용이 표시되지 않던 것을 수정.
- `src/types/mypage/inquiry.ts`: `InquiryStatus` 타입을 BE와 일치
- `src/components/mypage/inquiry/InquiryListItem.tsx`: 뱃지/답변 표시 조건

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] 문의 유형 enum `ACCOUNT_INFO` → `MEMBER_INFO`로 BE 계약과 일치 (문의 생성 400 해결)
- [x] 답변 상태 enum `COMPLETED` → `ANSWERED`로 BE 계약과 일치 (답변완료 뱃지/답변 표시 복구)
- [x] `tsc -b` 타입체크 통과 확인

원인: FE(#273, 05-17)가 BE 문의 enum(#544, 05-16)의 실제 문자열을 따르지 않고 의미만 같은 다른 이름으로 자체 명명해 발생. BE를 소스 오브 트루스로 두고 FE를 정렬. 기존 저장 데이터 영향 없음(잘못된 값은 400으로 저장된 적 없음).

<br>

## 📷 스크린샷

N/A (enum 문자열 정렬, UI 레이아웃 변경 없음)
