### PR TITLE
Refactor/v2 photo feed qa(#322)

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -11,6 +11,8 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-community-apple-sign-in')
     implementation project(':capacitor-app')
+    implementation project(':capacitor-file-transfer')
+    implementation project(':capacitor-filesystem')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-secure-storage-plugin')
     implementation project(':capacitor3-kakao-login')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -8,6 +8,12 @@ project(':capacitor-community-apple-sign-in').projectDir = new File('../node_mod
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-file-transfer'
+project(':capacitor-file-transfer').projectDir = new File('../node_modules/@capacitor/file-transfer/android')
+
+include ':capacitor-filesystem'
+project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@capacitor/android": "^8.3.4",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/file-transfer": "^2.0.4",
+    "@capacitor/filesystem": "^8.1.2",
     "@capacitor/ios": "^8.3.4",
     "@capacitor/splash-screen": "^8.0.1",
     "@portone/browser-sdk": "^0.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,15 +24,21 @@ importers:
       '@capacitor/core':
         specifier: ^8.3.4
         version: 8.3.4
+      '@capacitor/file-transfer':
+        specifier: ^2.0.4
+        version: 2.0.4(@capacitor/core@8.3.4)
+      '@capacitor/filesystem':
+        specifier: ^8.1.2
+        version: 8.1.2(@capacitor/core@8.3.4)
       '@capacitor/ios':
         specifier: ^8.3.4
         version: 8.3.4(@capacitor/core@8.3.4)
-      '@portone/browser-sdk':
-        specifier: ^0.1.8
-        version: 0.1.8
       '@capacitor/splash-screen':
         specifier: ^8.0.1
         version: 8.0.1(@capacitor/core@8.3.4)
+      '@portone/browser-sdk':
+        specifier: ^0.1.8
+        version: 0.1.8
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.3)
@@ -270,6 +276,16 @@ packages:
   '@capacitor/core@8.3.4':
     resolution: {integrity: sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==}
 
+  '@capacitor/file-transfer@2.0.4':
+    resolution: {integrity: sha512-tWHcLmUu1SMfQY1KUHLXK63c6rsyrPHAgbWh4eIqyg4B8cyyzVJQC+/T6tLehv262iO7lw0S7ebb/DU9GlNL4A==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/filesystem@8.1.2':
+    resolution: {integrity: sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
   '@capacitor/ios@8.3.4':
     resolution: {integrity: sha512-XvvnPFWWP/gwwO811ue7nEBKSZqDCIB8hxGgWV6iXA7DSVLqMOEmQdfHj94kkVxof2wL9XWHypu3ayDULo7U5w==}
     peerDependencies:
@@ -279,6 +295,9 @@ packages:
     resolution: {integrity: sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/synapse@1.0.4':
+    resolution: {integrity: sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -718,11 +737,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@prettier/plugin-xml@2.2.0':
-    resolution: {integrity: sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==}
-
   '@portone/browser-sdk@0.1.8':
     resolution: {integrity: sha512-/9DqqiJckIAaOiCMXYdX+Pyj1Mxa8COInaI7ziUa5KeqnBuE0Q2+7dNSNMor+q6WM7OtnrVqmRRv5cC+gc02sw==}
+
+  '@prettier/plugin-xml@2.2.0':
+    resolution: {integrity: sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -3195,6 +3214,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -3696,6 +3716,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@capacitor/file-transfer@2.0.4(@capacitor/core@8.3.4)':
+    dependencies:
+      '@capacitor/core': 8.3.4
+      '@capacitor/synapse': 1.0.4
+
+  '@capacitor/filesystem@8.1.2(@capacitor/core@8.3.4)':
+    dependencies:
+      '@capacitor/core': 8.3.4
+      '@capacitor/synapse': 1.0.4
+
   '@capacitor/ios@8.3.4(@capacitor/core@8.3.4)':
     dependencies:
       '@capacitor/core': 8.3.4
@@ -3703,6 +3733,8 @@ snapshots:
   '@capacitor/splash-screen@8.0.1(@capacitor/core@8.3.4)':
     dependencies:
       '@capacitor/core': 8.3.4
+
+  '@capacitor/synapse@1.0.4': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4105,11 +4137,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@portone/browser-sdk@0.1.8': {}
+
   '@prettier/plugin-xml@2.2.0':
     dependencies:
       '@xml-tools/parser': 1.0.11
       prettier: 3.7.4
-  '@portone/browser-sdk@0.1.8': {}
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 

--- a/src/apis/file/fileUpload.api.ts
+++ b/src/apis/file/fileUpload.api.ts
@@ -1,17 +1,108 @@
 // src/apis/file/uploadToPresignedUrl.api.ts
 import type { UploadToPresignedUrlArgs } from "@/types/file/presignedUrl";
-import axios from "axios";
+import { Capacitor } from "@capacitor/core";
+import { Filesystem, Directory } from "@capacitor/filesystem";
+import { FileTransfer } from "@capacitor/file-transfer";
 
-export async function uploadToPresignedUrl({
+const UPLOAD_TIMEOUT_MS = 60_000;
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("파일을 base64로 변환하지 못했습니다."));
+        return;
+      }
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+
+    reader.onerror = () => {
+      const domError = reader.error;
+      reject(
+        new Error(
+          `파일 읽기 실패: ${domError?.name ?? "unknown"} ${domError?.message ?? ""}`.trim(),
+        ),
+      );
+    };
+
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * 네이티브 앱에서는 GCS presigned URL PUT을 CapacitorHttp/브라우저 fetch가 아니라
+ * 네이티브 HTTP 클라이언트(@capacitor/file-transfer)로 직접 업로드한다.
+ * 브라우저 CORS 검사를 받지 않고, JS<->네이티브 브리지로 파일 바이트를 실어 나르지
+ * 않으므로 대용량/다중 이미지 동시 업로드 시 브리지 부하로 실패하던 문제도 사라진다.
+ */
+async function uploadViaNativeFileTransfer({
   url,
   file,
   contentType,
 }: UploadToPresignedUrlArgs): Promise<void> {
-  await axios.put(url, file, {
-    headers: {
-      "Content-Type": contentType,
-    },
-    withCredentials: false,
-    timeout: 60_000,
+  const tempPath = `uploads/${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const base64Data = await blobToBase64(file);
+
+  const { uri } = await Filesystem.writeFile({
+    path: tempPath,
+    data: base64Data,
+    directory: Directory.Cache,
+    recursive: true,
   });
+
+  try {
+    await FileTransfer.uploadFile({
+      url,
+      path: uri,
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      connectTimeout: UPLOAD_TIMEOUT_MS,
+      readTimeout: UPLOAD_TIMEOUT_MS,
+    });
+  } finally {
+    await Filesystem.deleteFile({
+      path: tempPath,
+      directory: Directory.Cache,
+    }).catch(() => {});
+  }
+}
+
+/** 순수 웹(브라우저) 환경: 네이티브 브리지가 없으므로 기존처럼 브라우저 fetch로 업로드 */
+async function uploadViaFetch({
+  url,
+  file,
+  contentType,
+}: UploadToPresignedUrlArgs): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      body: file,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `GCS 업로드 실패 (status: ${response.status} ${response.statusText})`,
+      );
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function uploadToPresignedUrl(
+  args: UploadToPresignedUrlArgs,
+): Promise<void> {
+  if (Capacitor.isNativePlatform()) {
+    await uploadViaNativeFileTransfer(args);
+  } else {
+    await uploadViaFetch(args);
+  }
 }

--- a/src/apis/photoFeed/index.ts
+++ b/src/apis/photoFeed/index.ts
@@ -4,6 +4,13 @@ export { getPosts, createPost, getPostDetail, deletePost } from "./post.api";
 
 export { postLike, deleteLike } from "./reactions.api";
 
+export { reportContent } from "./report.api";
+export type {
+  ReportTargetType,
+  ReportReason,
+  ReportRequest,
+} from "./report.api";
+
 export {
   getPostSearches,
   getRecentSearches,

--- a/src/apis/photoFeed/report.api.ts
+++ b/src/apis/photoFeed/report.api.ts
@@ -1,0 +1,33 @@
+import { axiosInstance } from "@/lib/axiosInstance";
+import type { ApiResponse } from "@/types/common/apiResponse";
+
+/** 신고 대상 타입 */
+export type ReportTargetType = "POST" | "COMMENT";
+
+/** 신고 사유 */
+export type ReportReason = "SPAM" | "PORN" | "ABUSE" | "PRIVACY" | "ILLEGAL";
+
+export type ReportRequest = {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+};
+
+/**
+ * 게시글/댓글 신고
+ * 타인이 작성한 게시글 또는 댓글을 신고한다.
+ */
+export async function reportContent(payload: ReportRequest): Promise<boolean> {
+  const res = await axiosInstance.post<ApiResponse<Record<string, never>>>(
+    "/reports",
+    payload,
+  );
+
+  const body = res.data;
+
+  if (!body.success) {
+    throw new Error(body.message);
+  }
+
+  return true;
+}

--- a/src/apis/photoFeed/search.api.ts
+++ b/src/apis/photoFeed/search.api.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { axiosInstance } from "@/lib/axiosInstance";
 import type { ApiResponse } from "@/types/common/apiResponse";
 import {
@@ -119,41 +118,23 @@ export async function getLabSearches({
   longitude,
   locationAgreed,
 }: LabSearchRequest): Promise<LabSearchResponse[]> {
-  try {
-    const res = await axiosInstance.get<ApiResponse<LabSearchResponseList>>(
-      "/photo-labs/search",
-      {
-        params: {
-          keyword,
-          latitude,
-          longitude,
-          locationAgreed,
-        },
+  const res = await axiosInstance.get<ApiResponse<LabSearchResponseList>>(
+    "/photo-labs/search",
+    {
+      params: {
+        keyword,
+        latitude,
+        longitude,
+        locationAgreed,
       },
-    );
+    },
+  );
 
-    const body = res.data;
+  const body = res.data;
 
-    if (!body.success) {
-      throw new Error(body.message);
-    }
-
-    return body.data.photoLabSearchList ?? []; // 검색 결과 리스트 return
-  } catch (error) {
-    // TODO: 원인 확인되면 이 임시 로깅은 제거
-    // Android logcat은 객체를 그대로 넘기면 [object Object]로만 찍히므로 문자열화해서 남긴다.
-    if (axios.isAxiosError(error)) {
-      console.error(
-        "[현상소 검색 실패] " +
-          JSON.stringify({
-            status: error.response?.status,
-            data: error.response?.data,
-            message: error.message,
-          }),
-      );
-    } else {
-      console.error("[현상소 검색 실패] Unknown error: " + String(error));
-    }
-    throw error;
+  if (!body.success) {
+    throw new Error(body.message);
   }
+
+  return body.data.photoLabSearchList ?? []; // 검색 결과 리스트 return
 }

--- a/src/apis/photoFeed/search.api.ts
+++ b/src/apis/photoFeed/search.api.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { axiosInstance } from "@/lib/axiosInstance";
 import type { ApiResponse } from "@/types/common/apiResponse";
 import {
@@ -118,23 +119,41 @@ export async function getLabSearches({
   longitude,
   locationAgreed,
 }: LabSearchRequest): Promise<LabSearchResponse[]> {
-  const res = await axiosInstance.get<ApiResponse<LabSearchResponseList>>(
-    "/photo-labs/search",
-    {
-      params: {
-        keyword,
-        latitude,
-        longitude,
-        locationAgreed,
+  try {
+    const res = await axiosInstance.get<ApiResponse<LabSearchResponseList>>(
+      "/photo-labs/search",
+      {
+        params: {
+          keyword,
+          latitude,
+          longitude,
+          locationAgreed,
+        },
       },
-    },
-  );
+    );
 
-  const body = res.data;
+    const body = res.data;
 
-  if (!body.success) {
-    throw new Error(body.message);
+    if (!body.success) {
+      throw new Error(body.message);
+    }
+
+    return body.data.photoLabSearchList ?? []; // 검색 결과 리스트 return
+  } catch (error) {
+    // TODO: 원인 확인되면 이 임시 로깅은 제거
+    // Android logcat은 객체를 그대로 넘기면 [object Object]로만 찍히므로 문자열화해서 남긴다.
+    if (axios.isAxiosError(error)) {
+      console.error(
+        "[현상소 검색 실패] " +
+          JSON.stringify({
+            status: error.response?.status,
+            data: error.response?.data,
+            message: error.message,
+          }),
+      );
+    } else {
+      console.error("[현상소 검색 실패] Unknown error: " + String(error));
+    }
+    throw error;
   }
-
-  return body.data.photoLabSearchList ?? []; // 검색 결과 리스트 return
 }

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -21,6 +21,11 @@ type TextAreaProps = {
   placeholder?: string;
   maxLength?: number;
   minLength?: number;
+  /**
+   * true(기본): maxLength를 넘기면 더 이상 입력 불가(하드 캡)
+   * false: 초과 입력을 허용하고, 초과 시 테두리·카운터가 빨갛게 표시
+   */
+  enforceMaxLength?: boolean;
   /** 입력 전 힌트: "min" = 최소 N자 이상 (기본), "max" = 최대 N자 이내 */
   emptyHint?: "min" | "max";
 
@@ -40,6 +45,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       placeholder = "",
       maxLength,
       minLength,
+      enforceMaxLength = true,
       emptyHint = "min",
       className = "",
       textareaClassName = "",
@@ -86,7 +92,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       <div
         className={[
           "flex flex-col gap-[0.625rem] rounded-2xl border bg-neutral-900 p-[1.25rem]",
-          isError ? "border-red-500" : "border-neutral-750",
+          isError || isOverMax ? "border-red-500" : "border-neutral-750",
           className,
         ]
           .filter(Boolean)
@@ -95,7 +101,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         <textarea
           ref={setRefs}
           value={value}
-          maxLength={maxLength}
+          maxLength={enforceMaxLength ? maxLength : undefined}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           disabled={disabled}
@@ -112,9 +118,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             typeof minLength === "number" ? (
             <span className="text-neutral-500">최소 {minLength}자 이상</span>
           ) : typeof maxLength === "number" ? (
-            <span
-              className={isOverMax ? "text-orange-500" : "text-neutral-400"}
-            >
+            <span className={isOverMax ? "text-red-500" : "text-neutral-400"}>
               {length}/{maxLength}
             </span>
           ) : null}

--- a/src/components/photoFeed/postDetail/ActionSheet.tsx
+++ b/src/components/photoFeed/postDetail/ActionSheet.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { createPortal } from "react-dom";
+import SheetPopup from "./SheetPopup";
 
 export type ActionSheetAction = {
   label: string;
@@ -19,50 +18,11 @@ export default function ActionSheet({
   actions,
   onClose,
 }: ActionSheetProps) {
-  // ESC 닫기
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
-
-  if (!open) return null;
-
-  const ui = (
-    <div className="fixed inset-0 z-500">
-      {/* backdrop */}
-      <button
-        type="button"
-        aria-label="닫기"
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60"
-      />
-
-      {/* sheet */}
-      <div className="absolute inset-x-0 bottom-0 gap-4 px-4">
-        <div className="bg-neutral-875 overflow-hidden rounded-3xl border border-neutral-800">
-          <div className="divide-y divide-white/10">
-            {actions.map((a) => (
-              <button
-                key={a.label}
-                type="button"
-                onClick={() => {
-                  a.onClick();
-                  onClose();
-                }}
-                className={`w-full py-4 text-center text-[0.9375rem] ${
-                  a.variant === "danger" ? "text-red-400" : "text-neutral-100"
-                }`}
-              >
-                {a.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
+  return (
+    <SheetPopup
+      open={open}
+      onClose={onClose}
+      footer={
         <button
           type="button"
           onClick={onClose}
@@ -70,9 +30,23 @@ export default function ActionSheet({
         >
           취소
         </button>
-      </div>
-    </div>
+      }
+    >
+      {actions.map((a) => (
+        <button
+          key={a.label}
+          type="button"
+          onClick={() => {
+            a.onClick();
+            onClose();
+          }}
+          className={`w-full py-4 text-center text-[0.9375rem] ${
+            a.variant === "danger" ? "text-red-400" : "text-neutral-100"
+          }`}
+        >
+          {a.label}
+        </button>
+      ))}
+    </SheetPopup>
   );
-
-  return createPortal(ui, document.body); // 무조건 body에 렌더링
 }

--- a/src/components/photoFeed/postDetail/Profile.tsx
+++ b/src/components/photoFeed/postDetail/Profile.tsx
@@ -1,9 +1,21 @@
-import { DefaultProfileIcon, EllipsisVerticalIcon } from "@/assets/icon";
-import { useCallback, useMemo, useState } from "react";
+import {
+  CheckCircleIcon,
+  DefaultProfileIcon,
+  EllipsisVerticalIcon,
+} from "@/assets/icon";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import ActionSheet, { type ActionSheetAction } from "./ActionSheet";
+import ReportSheet from "./ReportSheet";
+import { ToastItem } from "@/components/common";
 import { timeAgo } from "@/utils/timeAgo";
-import { useDeletePost, useDeleteComment } from "@/hooks/photoFeed";
+import {
+  useDeletePost,
+  useDeleteComment,
+  useReportContent,
+} from "@/hooks/photoFeed";
 import { useLocation, useNavigate } from "react-router";
+import { isAxiosError } from "axios";
 
 type ProfileType = "post" | "comment";
 
@@ -56,10 +68,41 @@ export default function Profile({
 
   const [moreMenu, setMoreMenu] = useState(false);
 
+  // 프로필 이미지 로드 실패 시 기본 아이콘으로 폴백
+  // 어떤 src에서 실패했는지 기록해, avatarUrl이 바뀌면 다시 시도
+  const [erroredSrc, setErroredSrc] = useState<string | null>(null);
+  const showAvatarFallback = !avatarUrl || erroredSrc === avatarUrl;
+
   const { mutateAsync: deletePostAsync, isPending: isPostPending } =
     useDeletePost();
   const { mutateAsync: deleteCommentAsync, isPending: isCommentPending } =
     useDeleteComment();
+
+  // 신고 사유 선택 시트 + 완료 토스트
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportedToast, setReportedToast] = useState(false);
+
+  const { mutate: report, isPending: isReporting } = useReportContent({
+    onSuccess: () => {
+      setReportOpen(false);
+      setReportedToast(true);
+    },
+    onError: (e) => {
+      // 서버가 400 등으로 거부하면 실제 사유는 response.data에 담겨온다.
+      if (isAxiosError(e)) {
+        console.error("신고 실패", e.response?.status, e.response?.data);
+      } else {
+        console.error("신고 실패", e);
+      }
+    }, // TODO 실패 토스트
+  });
+
+  // 신고 완료 토스트 자동 숨김
+  useEffect(() => {
+    if (!reportedToast) return;
+    const t = setTimeout(() => setReportedToast(false), 3000);
+    return () => clearTimeout(t);
+  }, [reportedToast]);
 
   const isPost = type === "post";
   const isComment = type === "comment";
@@ -93,8 +136,23 @@ export default function Profile({
   }, [isCommentPending, deleteCommentAsync, objectId]);
 
   const actions: ActionSheetAction[] = useMemo(() => {
-    // 메뉴 없는 케이스는 빈 배열
-    if (isComment && !isOwner) return [];
+    // 타인 댓글: 공유하기 + 신고하기 (공유는 게시글과 동일 로직)
+    if (isComment && !isOwner) {
+      return [
+        {
+          label: "공유하기",
+          onClick: async () => {
+            await shareCurrentUrl();
+            setMoreMenu(false);
+          },
+        },
+        {
+          label: "신고하기",
+          onClick: () => setReportOpen(true),
+        },
+      ];
+    }
+    // 타인 게시글: 공유하기 + 신고하기
     if (isPost && !isOwner) {
       return [
         {
@@ -105,6 +163,10 @@ export default function Profile({
             await shareCurrentUrl();
             setMoreMenu(false);
           },
+        },
+        {
+          label: "신고하기",
+          onClick: () => setReportOpen(true),
         },
       ];
     }
@@ -128,8 +190,15 @@ export default function Profile({
       ];
     }
 
-    // comment + owner
+    // 자기가 작성한 댓글: 공유하기 + 삭제하기
     return [
+      {
+        label: "공유하기",
+        onClick: async () => {
+          await shareCurrentUrl();
+          setMoreMenu(false);
+        },
+      },
       {
         label: "삭제하기",
         disabled: isCommentPending,
@@ -152,19 +221,20 @@ export default function Profile({
   return (
     <div className="flex items-start gap-2">
       {/* avatar */}
-      {avatarUrl ? (
+      {showAvatarFallback ? (
+        <DefaultProfileIcon
+          className="h-9 w-9 rounded-full"
+          width={36}
+          height={36}
+        />
+      ) : (
         <img
           src={avatarUrl}
           alt={userName ?? "프로필"}
           className="h-9 w-9 rounded-full"
           width={36}
           height={36}
-        />
-      ) : (
-        <DefaultProfileIcon
-          className="h-9 w-9 rounded-full"
-          width={36}
-          height={36}
+          onError={() => setErroredSrc(avatarUrl ?? null)}
         />
       )}
 
@@ -218,6 +288,32 @@ export default function Profile({
           actions={actions}
         />
       )}
+
+      {/* 신고 사유 선택 시트 */}
+      <ReportSheet
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        isSubmitting={isReporting}
+        onSubmit={(reason) =>
+          report({
+            targetType: isPost ? "POST" : "COMMENT",
+            targetId: objectId,
+            reason,
+          })
+        }
+      />
+
+      {/* 신고 완료 토스트 */}
+      {reportedToast &&
+        createPortal(
+          <div className="fixed bottom-[2rem] left-1/2 z-[9999] -translate-x-1/2">
+            <ToastItem
+              message={`${isPost ? "게시글" : "댓글"} 신고가 완료되었습니다.`}
+              icon={<CheckCircleIcon className="h-5 w-5" />}
+            />
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/photoFeed/postDetail/Profile.tsx
+++ b/src/components/photoFeed/postDetail/Profile.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import ActionSheet, { type ActionSheetAction } from "./ActionSheet";
 import ReportSheet from "./ReportSheet";
-import { ToastItem } from "@/components/common";
+import { ToastItem, ToastList } from "@/components/common";
 import { timeAgo } from "@/utils/timeAgo";
 import {
   useDeletePost,
@@ -36,19 +36,31 @@ function formatKoreanDate(iso: string) {
   return `${year}년 ${Number(month)}월 ${Number(day)}일`;
 }
 
-async function shareCurrentUrl() {
+type ShareResult = "shared" | "copied" | "cancelled" | "failed";
+
+async function shareCurrentUrl(): Promise<ShareResult> {
   const url = window.location.href;
 
+  // 네이티브/모바일: OS 공유 시트 (시트 자체가 피드백)
   if (navigator.share) {
-    await navigator.share({
-      title: "파인더스",
-      text: "게시글 공유",
-      url,
-    });
-    return;
+    try {
+      await navigator.share({ title: "파인더스", text: "게시글 공유", url });
+      return "shared";
+    } catch (e) {
+      // 사용자가 공유 시트를 닫으면 AbortError → 조용히 무시
+      return e instanceof Error && e.name === "AbortError"
+        ? "cancelled"
+        : "failed";
+    }
   }
 
-  await navigator.clipboard.writeText(url);
+  // 데스크톱 등 Web Share 미지원: 클립보드 복사 (호출부에서 토스트로 피드백)
+  try {
+    await navigator.clipboard.writeText(url);
+    return "copied";
+  } catch {
+    return "failed";
+  }
 }
 
 export default function Profile({
@@ -78,14 +90,16 @@ export default function Profile({
   const { mutateAsync: deleteCommentAsync, isPending: isCommentPending } =
     useDeleteComment();
 
-  // 신고 사유 선택 시트 + 완료 토스트
+  // 신고 사유 선택 시트 + 공용 토스트(신고 완료 / 링크 복사 등)
   const [reportOpen, setReportOpen] = useState(false);
-  const [reportedToast, setReportedToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const { mutate: report, isPending: isReporting } = useReportContent({
     onSuccess: () => {
       setReportOpen(false);
-      setReportedToast(true);
+      setToastMessage(
+        `${type === "post" ? "게시글" : "댓글"} 신고가 완료되었습니다.`,
+      );
     },
     onError: (e) => {
       // 서버가 400 등으로 거부하면 실제 사유는 response.data에 담겨온다.
@@ -97,12 +111,21 @@ export default function Profile({
     }, // TODO 실패 토스트
   });
 
-  // 신고 완료 토스트 자동 숨김
+  // 토스트 자동 숨김
   useEffect(() => {
-    if (!reportedToast) return;
-    const t = setTimeout(() => setReportedToast(false), 3000);
+    if (!toastMessage) return;
+    const t = setTimeout(() => setToastMessage(null), 3000);
     return () => clearTimeout(t);
-  }, [reportedToast]);
+  }, [toastMessage]);
+
+  // 공유하기: 공유 시트(모바일) 또는 클립보드 복사(데스크톱). 복사 시 토스트로 안내.
+  const handleShare = useCallback(async () => {
+    const result = await shareCurrentUrl();
+    if (result === "copied") {
+      setToastMessage("링크가 복사되었습니다.");
+    }
+    setMoreMenu(false);
+  }, []);
 
   const isPost = type === "post";
   const isComment = type === "comment";
@@ -136,51 +159,24 @@ export default function Profile({
   }, [isCommentPending, deleteCommentAsync, objectId]);
 
   const actions: ActionSheetAction[] = useMemo(() => {
-    // 타인 댓글: 공유하기 + 신고하기 (공유는 게시글과 동일 로직)
+    // 타인 댓글: 공유하기 + 신고하기
     if (isComment && !isOwner) {
       return [
-        {
-          label: "공유하기",
-          onClick: async () => {
-            await shareCurrentUrl();
-            setMoreMenu(false);
-          },
-        },
-        {
-          label: "신고하기",
-          onClick: () => setReportOpen(true),
-        },
+        { label: "공유하기", onClick: handleShare },
+        { label: "신고하기", onClick: () => setReportOpen(true) },
       ];
     }
     // 타인 게시글: 공유하기 + 신고하기
     if (isPost && !isOwner) {
       return [
-        {
-          label: "공유하기",
-          disabled: isPostPending,
-          onClick: async () => {
-            if (isPostPending) return;
-            await shareCurrentUrl();
-            setMoreMenu(false);
-          },
-        },
-        {
-          label: "신고하기",
-          onClick: () => setReportOpen(true),
-        },
+        { label: "공유하기", onClick: handleShare },
+        { label: "신고하기", onClick: () => setReportOpen(true) },
       ];
     }
-
+    // 내 게시글: 공유하기 + 삭제하기
     if (isPost && isOwner) {
       return [
-        {
-          label: "공유하기",
-          disabled: isPostPending,
-          onClick: async () => {
-            await shareCurrentUrl();
-            setMoreMenu(false);
-          },
-        },
+        { label: "공유하기", onClick: handleShare },
         {
           label: "삭제하기",
           disabled: isPostPending,
@@ -189,16 +185,9 @@ export default function Profile({
         },
       ];
     }
-
-    // 자기가 작성한 댓글: 공유하기 + 삭제하기
+    // 내 댓글: 공유하기 + 삭제하기
     return [
-      {
-        label: "공유하기",
-        onClick: async () => {
-          await shareCurrentUrl();
-          setMoreMenu(false);
-        },
-      },
+      { label: "공유하기", onClick: handleShare },
       {
         label: "삭제하기",
         disabled: isCommentPending,
@@ -207,6 +196,7 @@ export default function Profile({
       },
     ];
   }, [
+    handleShare,
     handleDeletePost,
     handleDeleteComment,
     isComment,
@@ -303,15 +293,15 @@ export default function Profile({
         }
       />
 
-      {/* 신고 완료 토스트 */}
-      {reportedToast &&
+      {/* 공용 토스트 (신고 완료 / 링크 복사 등) */}
+      {toastMessage &&
         createPortal(
-          <div className="fixed bottom-[2rem] left-1/2 z-[9999] -translate-x-1/2">
+          <ToastList>
             <ToastItem
-              message={`${isPost ? "게시글" : "댓글"} 신고가 완료되었습니다.`}
+              message={toastMessage}
               icon={<CheckCircleIcon className="h-5 w-5" />}
             />
-          </div>,
+          </ToastList>,
           document.body,
         )}
     </div>

--- a/src/components/photoFeed/postDetail/ReportSheet.tsx
+++ b/src/components/photoFeed/postDetail/ReportSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import SheetPopup from "./SheetPopup";
 import type { ReportReason } from "@/apis/photoFeed/report.api";
 
 /** 신고 사유 옵션 (피그마 기획 순서) */
@@ -26,53 +26,16 @@ export default function ReportSheet({
 }: ReportSheetProps) {
   const [selected, setSelected] = useState<ReportReason | null>(null);
 
-  // ESC 닫기
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
-
   // 열릴 때마다 선택 초기화
   useEffect(() => {
     if (open) setSelected(null);
   }, [open]);
 
-  if (!open) return null;
-
-  const ui = (
-    <div className="fixed inset-0 z-500">
-      {/* backdrop */}
-      <button
-        type="button"
-        aria-label="닫기"
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60"
-      />
-
-      {/* sheet */}
-      <div className="absolute inset-x-0 bottom-0 gap-4 px-4">
-        <div className="bg-neutral-875 overflow-hidden rounded-3xl border border-neutral-800">
-          <div className="divide-y divide-white/10">
-            {REPORT_REASONS.map((r) => (
-              <button
-                key={r.value}
-                type="button"
-                onClick={() => setSelected(r.value)}
-                className={`w-full py-4 text-center text-[0.9375rem] ${
-                  selected === r.value ? "text-red-400" : "text-neutral-100"
-                }`}
-              >
-                {r.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* 하단: 신고하기 (옵션 선택 시 활성/빨간색) */}
+  return (
+    <SheetPopup
+      open={open}
+      onClose={onClose}
+      footer={
         <button
           type="button"
           disabled={!selected || isSubmitting}
@@ -85,9 +48,20 @@ export default function ReportSheet({
         >
           신고하기
         </button>
-      </div>
-    </div>
+      }
+    >
+      {REPORT_REASONS.map((r) => (
+        <button
+          key={r.value}
+          type="button"
+          onClick={() => setSelected(r.value)}
+          className={`w-full py-4 text-center text-[0.9375rem] ${
+            selected === r.value ? "text-red-400" : "text-neutral-100"
+          }`}
+        >
+          {r.label}
+        </button>
+      ))}
+    </SheetPopup>
   );
-
-  return createPortal(ui, document.body);
 }

--- a/src/components/photoFeed/postDetail/ReportSheet.tsx
+++ b/src/components/photoFeed/postDetail/ReportSheet.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import type { ReportReason } from "@/apis/photoFeed/report.api";
+
+/** 신고 사유 옵션 (피그마 기획 순서) */
+const REPORT_REASONS: { value: ReportReason; label: string }[] = [
+  { value: "SPAM", label: "스팸/홍보" },
+  { value: "PORN", label: "음란물" },
+  { value: "ABUSE", label: "욕설/혐오 표현" },
+  { value: "PRIVACY", label: "개인정보 노출" },
+  { value: "ILLEGAL", label: "불법 정보" },
+];
+
+interface ReportSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (reason: ReportReason) => void;
+  isSubmitting?: boolean;
+}
+
+export default function ReportSheet({
+  open,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+}: ReportSheetProps) {
+  const [selected, setSelected] = useState<ReportReason | null>(null);
+
+  // ESC 닫기
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  // 열릴 때마다 선택 초기화
+  useEffect(() => {
+    if (open) setSelected(null);
+  }, [open]);
+
+  if (!open) return null;
+
+  const ui = (
+    <div className="fixed inset-0 z-500">
+      {/* backdrop */}
+      <button
+        type="button"
+        aria-label="닫기"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60"
+      />
+
+      {/* sheet */}
+      <div className="absolute inset-x-0 bottom-0 gap-4 px-4">
+        <div className="bg-neutral-875 overflow-hidden rounded-3xl border border-neutral-800">
+          <div className="divide-y divide-white/10">
+            {REPORT_REASONS.map((r) => (
+              <button
+                key={r.value}
+                type="button"
+                onClick={() => setSelected(r.value)}
+                className={`w-full py-4 text-center text-[0.9375rem] ${
+                  selected === r.value ? "text-red-400" : "text-neutral-100"
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 하단: 신고하기 (옵션 선택 시 활성/빨간색) */}
+        <button
+          type="button"
+          disabled={!selected || isSubmitting}
+          onClick={() => {
+            if (selected) onSubmit(selected);
+          }}
+          className={`bg-neutral-875 my-4 w-full rounded-3xl border border-neutral-800 py-4 text-center text-[0.9375rem] ${
+            selected ? "text-red-400" : "text-neutral-500"
+          }`}
+        >
+          신고하기
+        </button>
+      </div>
+    </div>
+  );
+
+  return createPortal(ui, document.body);
+}

--- a/src/components/photoFeed/postDetail/SheetPopup.tsx
+++ b/src/components/photoFeed/postDetail/SheetPopup.tsx
@@ -1,0 +1,55 @@
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface SheetPopupProps {
+  open: boolean;
+  onClose: () => void;
+  /** 상단 둥근 리스트 영역에 들어갈 항목들 (divide-y로 구분됨) */
+  children: ReactNode;
+  /** 리스트 아래 별도 버튼 (취소 / 신고하기 등) */
+  footer?: ReactNode;
+}
+
+/**
+ * 하단에서 올라오는 팝업 시트의 공용 레이아웃.
+ * ActionSheet(공유/삭제/신고 메뉴)와 ReportSheet(신고 사유 선택)가 동일 UI로 재사용한다.
+ */
+export default function SheetPopup({
+  open,
+  onClose,
+  children,
+  footer,
+}: SheetPopupProps) {
+  // ESC 닫기
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-500">
+      {/* backdrop */}
+      <button
+        type="button"
+        aria-label="닫기"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60"
+      />
+
+      {/* sheet */}
+      <div className="absolute inset-x-0 bottom-0 gap-4 px-4">
+        <div className="bg-neutral-875 overflow-hidden rounded-3xl border border-neutral-800">
+          <div className="divide-y divide-white/10">{children}</div>
+        </div>
+        {footer}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/hooks/photoFeed/comments/useCreateComment.ts
+++ b/src/hooks/photoFeed/comments/useCreateComment.ts
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { postComment } from "@/apis/photoFeed/comment.api";
 import type { PostComment } from "@/types/photoFeed/postDetail";
+import { patchPostInFeed } from "@/hooks/photoFeed/updateFeedCache";
 
 type CreateCommentResult = PostComment;
 type CreateCommentVars = { postId: string; content: string };
@@ -28,7 +29,17 @@ export function useCreateComment(
     mutationFn: ({ postId, content }) => postComment(postId, content),
     ...options,
     onSuccess: (data, vars, onMutateResult, ctx) => {
+      // 댓글 리스트 최신화
       queryClient.invalidateQueries({ queryKey: ["comments", vars.postId] });
+      // 상세 헤더의 댓글 수 갱신
+      queryClient.invalidateQueries({
+        queryKey: ["postDetail", vars.postId],
+      });
+      // 피드 카드의 댓글 수도 즉시 +1 (전체 리페치 없이)
+      patchPostInFeed(queryClient, vars.postId, (p) => ({
+        ...p,
+        commentCount: p.commentCount + 1,
+      }));
       options?.onSuccess?.(data, vars, onMutateResult, ctx);
     },
   });

--- a/src/hooks/photoFeed/index.ts
+++ b/src/hooks/photoFeed/index.ts
@@ -1,4 +1,5 @@
 export * from "./comments";
 export * from "./posts";
 export * from "./reactions";
+export * from "./report";
 export * from "./search";

--- a/src/hooks/photoFeed/posts/useCreatePostWithUpload.ts
+++ b/src/hooks/photoFeed/posts/useCreatePostWithUpload.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useIssuePresignedUrl, useUploadToPresignedUrl } from "@/hooks/file";
 import { useCreatePost } from "@/hooks/photoFeed/posts/useCreatePost";
 import type { PostRequestImage } from "@/types/photoFeed/postDetail";
@@ -23,6 +24,7 @@ type Options = {
 };
 
 export function useCreatePostWithUpload(options?: Options) {
+  const queryClient = useQueryClient();
   const issuePresigned = useIssuePresignedUrl();
   const uploadToPresigned = useUploadToPresignedUrl();
 
@@ -90,9 +92,17 @@ export function useCreatePostWithUpload(options?: Options) {
         reviewContent,
       });
 
+      // 5) 사진수다 피드 최신화 (새 글이 바로 보이도록)
+      // 등록 성공 시 상세 페이지로 이동해 피드 쿼리가 비활성 상태이므로,
+      // refetchType: "all"로 마운트 여부와 무관하게 즉시 갱신한다.
+      queryClient.invalidateQueries({
+        queryKey: ["photoFeed"],
+        refetchType: "all",
+      });
+
       return postId;
     },
-    [issuePresigned, uploadToPresigned, createPost],
+    [issuePresigned, uploadToPresigned, createPost, queryClient],
   );
 
   const isPending =

--- a/src/hooks/photoFeed/posts/useDeletePost.ts
+++ b/src/hooks/photoFeed/posts/useDeletePost.ts
@@ -9,7 +9,12 @@ export function useDeletePost() {
 
     onSuccess: (_data, postId) => {
       // 1) 피드 리스트 최신화
-      queryClient.invalidateQueries({ queryKey: ["photoFeed"] });
+      // 삭제 후 피드로 이동하는 흐름이라 이 시점엔 피드 쿼리가 비활성 상태일 수 있으므로,
+      // refetchType: "all"로 마운트 여부와 무관하게 즉시 갱신한다.
+      queryClient.invalidateQueries({
+        queryKey: ["photoFeed"],
+        refetchType: "all",
+      });
 
       // 2) 게시글 상세 최신화/제거
       queryClient.invalidateQueries({ queryKey: ["postDetail", postId] });

--- a/src/hooks/photoFeed/posts/useInfinitePosts.ts
+++ b/src/hooks/photoFeed/posts/useInfinitePosts.ts
@@ -17,11 +17,17 @@ export function useInfinitePosts() {
     getNextPageParam: (lastPage, allPages) =>
       lastPage.previewList.length < PAGE_SIZE ? undefined : allPages.length,
 
-    staleTime: 1000 * 60, // 1분 동안은 "신선" → 마운트돼도 refetch 안 함
+    // [갱신 전략]
+    // 무한스크롤 피드는 자동 리페치를 모두 끈다. 복귀/포커스마다 리페치하면
+    // 로드된 여러 페이지를 다시 받아오며 스크롤 위치가 깨지기 때문.
+    // 대신 최신화는 mutation이 책임진다:
+    //  - 좋아요/댓글: 캐시를 직접 patch (patchPostInFeed) → 전체 리페치 없이 카운트 반영
+    //  - 글 작성/삭제: invalidateQueries({ refetchType: "all" })로 즉시 전체 갱신
+    staleTime: 1000 * 60, // 1분간 신선 취급
     gcTime: 1000 * 60 * 5, // 5분간 캐시 유지
-    refetchOnMount: false, // 컴포넌트 마운트 시 재요청 막기
-    refetchOnWindowFocus: false, // 탭 다시 클릭/포커스 시 재요청 막기
-    refetchOnReconnect: false, // 네트워크 재연결 시 재요청 막기
-    retry: 1, // 실패 시 재시도 횟수 줄이기
+    refetchOnMount: false, // 복귀 시 재요청 안 함(스크롤/페이지 보존)
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 1,
   });
 }

--- a/src/hooks/photoFeed/reactions/useLikePost.ts
+++ b/src/hooks/photoFeed/reactions/useLikePost.ts
@@ -2,6 +2,11 @@ import { postLike } from "@/apis/photoFeed";
 import type { PostDetailResponse } from "@/types/photoFeed/postDetail";
 import type { CommunityPost } from "@/apis/mainPage/mainPage.api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  PHOTO_FEED_QK,
+  patchPostInFeed,
+  restoreFeedCache,
+} from "@/hooks/photoFeed/updateFeedCache";
 
 const COMMUNITY_PREVIEW_QK = ["community", "posts", "preview"] as const;
 const POST_DETAIL_QK = (postId: string) => ["postDetail", postId] as const;
@@ -17,6 +22,7 @@ export function useLikePost() {
       await Promise.all([
         queryClient.cancelQueries({ queryKey: POST_DETAIL_QK(postId) }),
         queryClient.cancelQueries({ queryKey: COMMUNITY_PREVIEW_QK }),
+        queryClient.cancelQueries({ queryKey: PHOTO_FEED_QK }),
       ]);
 
       const prevDetail = queryClient.getQueryData<PostDetailResponse>(
@@ -24,6 +30,13 @@ export function useLikePost() {
       );
       const prevPreview =
         queryClient.getQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK);
+
+      // 피드 카드의 좋아요 수/여부도 즉시 반영 (전체 리페치 없이)
+      const prevFeed = patchPostInFeed(queryClient, postId, (p) => ({
+        ...p,
+        isLiked: true,
+        likeCount: p.likeCount + 1,
+      }));
 
       queryClient.setQueryData(
         POST_DETAIL_QK(postId),
@@ -49,7 +62,7 @@ export function useLikePost() {
         ),
       );
 
-      return { prevDetail, prevPreview };
+      return { prevDetail, prevPreview, prevFeed };
     },
 
     onError: (_err, postId, context) => {
@@ -59,6 +72,7 @@ export function useLikePost() {
       if (context?.prevPreview) {
         queryClient.setQueryData(COMMUNITY_PREVIEW_QK, context.prevPreview);
       }
+      restoreFeedCache(queryClient, context?.prevFeed);
     },
 
     onSuccess: (_data, postId) => {

--- a/src/hooks/photoFeed/reactions/useUnlikePost.ts
+++ b/src/hooks/photoFeed/reactions/useUnlikePost.ts
@@ -2,6 +2,11 @@ import { deleteLike } from "@/apis/photoFeed";
 import type { PostDetailResponse } from "@/types/photoFeed/postDetail";
 import type { CommunityPost } from "@/apis/mainPage/mainPage.api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  PHOTO_FEED_QK,
+  patchPostInFeed,
+  restoreFeedCache,
+} from "@/hooks/photoFeed/updateFeedCache";
 
 const COMMUNITY_PREVIEW_QK = ["community", "posts", "preview"] as const;
 const POST_DETAIL_QK = (postId: string) => ["postDetail", postId] as const;
@@ -17,6 +22,7 @@ export function useUnlikePost() {
       await Promise.all([
         queryClient.cancelQueries({ queryKey: POST_DETAIL_QK(postId) }),
         queryClient.cancelQueries({ queryKey: COMMUNITY_PREVIEW_QK }),
+        queryClient.cancelQueries({ queryKey: PHOTO_FEED_QK }),
       ]);
 
       const prevDetail = queryClient.getQueryData<PostDetailResponse>(
@@ -24,6 +30,13 @@ export function useUnlikePost() {
       );
       const prevPreview =
         queryClient.getQueryData<CommunityPost[]>(COMMUNITY_PREVIEW_QK);
+
+      // 피드 카드의 좋아요 수/여부도 즉시 반영 (전체 리페치 없이)
+      const prevFeed = patchPostInFeed(queryClient, postId, (p) => ({
+        ...p,
+        isLiked: false,
+        likeCount: Math.max(0, p.likeCount - 1),
+      }));
 
       queryClient.setQueryData(
         POST_DETAIL_QK(postId),
@@ -49,7 +62,7 @@ export function useUnlikePost() {
         ),
       );
 
-      return { prevDetail, prevPreview };
+      return { prevDetail, prevPreview, prevFeed };
     },
 
     onError: (_err, postId, context) => {
@@ -59,6 +72,7 @@ export function useUnlikePost() {
       if (context?.prevPreview) {
         queryClient.setQueryData(COMMUNITY_PREVIEW_QK, context.prevPreview);
       }
+      restoreFeedCache(queryClient, context?.prevFeed);
     },
 
     onSuccess: (_data, postId) => {

--- a/src/hooks/photoFeed/report/index.ts
+++ b/src/hooks/photoFeed/report/index.ts
@@ -1,0 +1,1 @@
+export { useReportContent } from "./useReportContent";

--- a/src/hooks/photoFeed/report/useReportContent.ts
+++ b/src/hooks/photoFeed/report/useReportContent.ts
@@ -1,0 +1,16 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import { reportContent } from "@/apis/photoFeed/report.api";
+import type { ReportRequest } from "@/apis/photoFeed/report.api";
+
+/**
+ * 게시글/댓글 신고 mutation
+ */
+export function useReportContent(
+  options?: UseMutationOptions<boolean, Error, ReportRequest>,
+) {
+  return useMutation<boolean, Error, ReportRequest>({
+    mutationKey: ["report"],
+    mutationFn: reportContent,
+    ...options,
+  });
+}

--- a/src/hooks/photoFeed/updateFeedCache.ts
+++ b/src/hooks/photoFeed/updateFeedCache.ts
@@ -1,0 +1,50 @@
+import type { QueryClient, InfiniteData } from "@tanstack/react-query";
+import {
+  PAGE_SIZE,
+  type PhotoFeedResponse,
+  type PostPreview,
+} from "@/types/photoFeed/postPreview";
+
+/** 사진수다 메인 피드 무한쿼리 키 (useInfinitePosts와 동일해야 함) */
+export const PHOTO_FEED_QK = ["photoFeed", PAGE_SIZE] as const;
+
+type FeedCache = InfiniteData<PhotoFeedResponse>;
+
+/**
+ * 피드 무한쿼리 캐시에서 특정 게시글 한 건을 patch한다.
+ * - 캐시에 없거나 해당 글이 로드되지 않았으면 no-op (안전)
+ * - refetchOnMount:false인 피드를 전체 리페치 없이 즉시 최신화하는 용도
+ * @returns 롤백용 이전 캐시 스냅샷
+ */
+export function patchPostInFeed(
+  queryClient: QueryClient,
+  postId: string,
+  patch: (p: PostPreview) => PostPreview,
+): FeedCache | undefined {
+  const prev = queryClient.getQueryData<FeedCache>(PHOTO_FEED_QK);
+
+  queryClient.setQueryData<FeedCache>(PHOTO_FEED_QK, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        previewList: page.previewList.map((p) =>
+          p.postId === postId ? patch(p) : p,
+        ),
+      })),
+    };
+  });
+
+  return prev;
+}
+
+/** 롤백: 스냅샷이 있으면 피드 캐시를 되돌린다. */
+export function restoreFeedCache(
+  queryClient: QueryClient,
+  snapshot: FeedCache | undefined,
+) {
+  if (snapshot) {
+    queryClient.setQueryData(PHOTO_FEED_QK, snapshot);
+  }
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -11,9 +11,8 @@ export default function RootLayout() {
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
 
-    let handle: { remove: () => void } | undefined;
-
-    App.addListener("backButton", ({ canGoBack }) => {
+    // Promise 자체를 붙잡아, resolve 타이밍과 무관하게 클린업에서 리스너를 제거한다.
+    const handlePromise = App.addListener("backButton", ({ canGoBack }) => {
       // 게시글 등록 직후엔 하드웨어 뒤로가기도 이전 작성 단계가 아니라 피드로 이동
       if (useNewPostState.getState().isNewPost) {
         useNewPostState.getState().setIsNewPost(false);
@@ -26,12 +25,10 @@ export default function RootLayout() {
       } else {
         App.exitApp();
       }
-    }).then((listenerHandle) => {
-      handle = listenerHandle;
     });
 
     return () => {
-      handle?.remove();
+      handlePromise.then((handle) => handle.remove());
     };
   }, [navigate]);
 

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,7 +1,40 @@
+import { useEffect } from "react";
+import { useNavigate, Outlet } from "react-router";
+import { App } from "@capacitor/app";
+import { Capacitor } from "@capacitor/core";
 import GlobalLoginDialog from "@/components/common/GlobalLoginDialog";
-import { Outlet } from "react-router";
+import { useNewPostState } from "@/store/useNewPostState.store";
 
 export default function RootLayout() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    let handle: { remove: () => void } | undefined;
+
+    App.addListener("backButton", ({ canGoBack }) => {
+      // 게시글 등록 직후엔 하드웨어 뒤로가기도 이전 작성 단계가 아니라 피드로 이동
+      if (useNewPostState.getState().isNewPost) {
+        useNewPostState.getState().setIsNewPost(false);
+        navigate("/photoFeed");
+        return;
+      }
+
+      if (canGoBack) {
+        navigate(-1);
+      } else {
+        App.exitApp();
+      }
+    }).then((listenerHandle) => {
+      handle = listenerHandle;
+    });
+
+    return () => {
+      handle?.remove();
+    };
+  }, [navigate]);
+
   return (
     <div className="min-h-dvh w-full bg-neutral-900 text-neutral-100">
       <GlobalLoginDialog />

--- a/src/pages/photoFeed/FindPhotoLabPage.tsx
+++ b/src/pages/photoFeed/FindPhotoLabPage.tsx
@@ -193,7 +193,7 @@ export default function FindPhotoLabPage() {
         </div>
       );
     }
-    if (!data) {
+    if (!data || data.length === 0) {
       return <EmptyView />;
     }
     return (

--- a/src/pages/photoFeed/FindPhotoLabPage.tsx
+++ b/src/pages/photoFeed/FindPhotoLabPage.tsx
@@ -96,7 +96,10 @@ export default function FindPhotoLabPage() {
         isSelfDeveloped: isSelf,
       });
     } catch (e) {
-      console.error("게시글 업로드 실패", e);
+      // Android logcat은 객체를 그대로 넘기면 [object Object]로만 찍히므로 문자열화해서 남긴다.
+      console.error(
+        "게시글 업로드 실패: " + (e instanceof Error ? e.message : String(e)),
+      );
     }
   };
 

--- a/src/pages/photoFeed/FindPhotoLabPage.tsx
+++ b/src/pages/photoFeed/FindPhotoLabPage.tsx
@@ -252,8 +252,13 @@ export default function FindPhotoLabPage() {
   };
 
   return (
-    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] py-[1rem]">
-      <Header title="현상소 입력하기" showBack onBack={handleGoBack} />
+    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
+      <Header
+        title="현상소 입력하기"
+        showBack
+        onBack={handleGoBack}
+        className="sticky top-0 z-50 bg-neutral-900"
+      />
 
       {/* 검색모드일 때: 화면 전체 클릭을 감지하는 투명 오버레이 */}
       {labReviewStep === "search" && (

--- a/src/pages/photoFeed/NewPostPage.tsx
+++ b/src/pages/photoFeed/NewPostPage.tsx
@@ -41,6 +41,19 @@ export default function NewPostPage() {
     }
   }, [files.length, navigate]);
 
+  // 뒤로가기로 연 갤러리를 취소(사진 미선택)하면 작성 플로우를 벗어나 피드로.
+  // (취소 시 그냥 두면 페이지에 갇히므로 cancel 이벤트를 탈출 경로로 사용)
+  useEffect(() => {
+    const el = galleryInputRef.current;
+    if (!el) return;
+    const handleCancel = () => {
+      useNewPostState.getState().reset();
+      navigate("/photoFeed", { replace: true });
+    };
+    el.addEventListener("cancel", handleCancel);
+    return () => el.removeEventListener("cancel", handleCancel);
+  }, [navigate]);
+
   const limitedFiles = useMemo(() => files.slice(0, LIMITS.maxPhotos), [files]);
 
   const isTitleValid = useMemo(
@@ -156,7 +169,7 @@ export default function NewPostPage() {
             isError={titleError}
           />
           {titleText.length > LIMITS.titleMax ? (
-            <p className="px-[0.625rem] text-[0.875rem] font-normal text-red-500">
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
               최대 {LIMITS.titleMax}자까지 입력 가능합니다.
             </p>
           ) : titleError ? (
@@ -188,7 +201,7 @@ export default function NewPostPage() {
             isError={contentError}
           />
           {contentText.length > LIMITS.contentMax ? (
-            <p className="px-[0.625rem] text-[0.875rem] font-normal text-red-500">
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
               최대 {LIMITS.contentMax}자까지 입력 가능합니다.
             </p>
           ) : contentError ? (

--- a/src/pages/photoFeed/NewPostPage.tsx
+++ b/src/pages/photoFeed/NewPostPage.tsx
@@ -20,10 +20,10 @@ export default function NewPostPage() {
   const [contentError, setContentError] = useState(false);
   const titleRef = useRef<HTMLTextAreaElement | null>(null);
   const contentRef = useRef<HTMLTextAreaElement | null>(null);
+  const galleryInputRef = useRef<HTMLInputElement | null>(null);
 
   const files = useNewPostState((s) => s.files);
   const setPostInfo = useNewPostState((s) => s.setPostInfo);
-  const reset = useNewPostState((s) => s.reset);
 
   const title = useNewPostState((s) => s.title);
   const content = useNewPostState((s) => s.content);
@@ -88,14 +88,29 @@ export default function NewPostPage() {
   };
 
   return (
-    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] py-[1rem]">
+    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
+      {/* 뒤로가기 시 다시 여는 네이티브 갤러리(파일 선택) */}
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={async (e) => {
+          const picked = Array.from(e.target.files ?? []);
+          e.currentTarget.value = ""; // 같은 파일 재선택 대비
+          if (picked.length === 0) return; // 갤러리 취소 시 현재 화면 유지
+          await useNewPostState.getState().setFiles(picked);
+        }}
+      />
       <Header
         title="글 작성하기"
         showBack
         onBack={() => {
-          reset();
-          navigate(-1);
+          // 헤더 뒤로가기 → 네이티브 갤러리를 다시 연다.
+          galleryInputRef.current?.click();
         }}
+        className="sticky top-0 z-50 bg-neutral-900"
       />
       {/* 선택된 사진 슬라이딩 */}
       <div
@@ -137,15 +152,18 @@ export default function NewPostPage() {
             placeholder="제목을 입력해주세요."
             minLength={LIMITS.titleMin}
             maxLength={LIMITS.titleMax}
+            enforceMaxLength={false}
             isError={titleError}
           />
-          {titleError && (
-            <p
-              className={`px-[0.625rem] text-[0.875rem] font-normal text-orange-500`}
-            >
+          {titleText.length > LIMITS.titleMax ? (
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-red-500">
+              최대 {LIMITS.titleMax}자까지 입력 가능합니다.
+            </p>
+          ) : titleError ? (
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
               최소 2글자 이상 입력해주세요.
             </p>
-          )}
+          ) : null}
         </section>
 
         <section className="flex flex-col gap-[0.5rem]">
@@ -166,15 +184,18 @@ export default function NewPostPage() {
             placeholder="나만의 필름 사진 이야기를 공유해주세요."
             minLength={LIMITS.contentMin}
             maxLength={LIMITS.contentMax}
+            enforceMaxLength={false}
             isError={contentError}
           />
-          {contentError && (
-            <p
-              className={`px-[0.625rem] text-[0.875rem] font-normal text-orange-500`}
-            >
+          {contentText.length > LIMITS.contentMax ? (
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-red-500">
+              최대 {LIMITS.contentMax}자까지 입력 가능합니다.
+            </p>
+          ) : contentError ? (
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
               최소 20글자 이상 입력해주세요.
             </p>
-          )}
+          ) : null}
         </section>
 
         <hr className="border-neutral-800" />

--- a/src/pages/photoFeed/PhotoFeedPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedPage.tsx
@@ -35,11 +35,29 @@ export default function PhotoFeedPage() {
   // 게시글 삭제 여부 정보
   const navigate = useNavigate();
   const location = useLocation();
-  const { isDeleted } = location.state ?? {};
+
+  // 최초 진입 시점의 삭제 여부를 로컬로 "고정"한다.
+  // (라우터 state를 직접 읽으면, 아래에서 state를 비운 뒤 뒤로가기로 재진입 시 값이 흔들림)
+  const [isDeleted] = useState(
+    () => !!(location.state as { isDeleted?: boolean } | null)?.isDeleted,
+  );
 
   // 토스트 메세지 관련 상태
   const [toastVisible, setToastVisible] = useState(isDeleted);
   const [mounted, setMounted] = useState(isDeleted);
+
+  // 라우터 state를 "즉시" 비운다.
+  // 3초 타이머 안에서 지우면, 그 전에 다른 페이지로 이동할 경우 state가 남아
+  // 뒤로가기로 돌아왔을 때 토스트가 다시 뜨는 버그가 생긴다.
+  useEffect(() => {
+    const state = location.state as { isDeleted?: boolean } | null;
+    if (state?.isDeleted) {
+      navigate(location.pathname + location.search, {
+        replace: true,
+        state: null,
+      });
+    }
+  }, [location, navigate]);
 
   useEffect(() => {
     if (!isDeleted) return;
@@ -48,16 +66,16 @@ export default function PhotoFeedPage() {
       () => setToastVisible(false),
       TOAST_FADE_START_DELAY,
     );
-    const removeTimer = setTimeout(() => {
-      setMounted(false);
-      navigate(location.pathname, { replace: true }); // 타이머 없앨 때 state도 같이 삭제
-    }, TOAST_UNMOUNT_DELAY);
+    const removeTimer = setTimeout(
+      () => setMounted(false),
+      TOAST_UNMOUNT_DELAY,
+    );
 
     return () => {
       clearTimeout(fadeTimer);
       clearTimeout(removeTimer);
     };
-  }, [isDeleted, navigate, location.pathname]);
+  }, [isDeleted]);
 
   const {
     data,
@@ -138,7 +156,7 @@ export default function PhotoFeedPage() {
                 <PhotoCard
                   key={postPreview.postId}
                   photo={postPreview}
-                  isLiked={false}
+                  isLiked={postPreview.isLiked}
                 />
               ))}
         </Masonry>

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -343,7 +343,12 @@ export default function PhotoFeedSearchPage() {
     showBack: true,
     onBack: () => {
       if (mode === "recent" || mode === "related") navigate(-1);
-      else if (mode === "result") resetToRecent();
+      else if (mode === "result") {
+        // 검색 결과 → 검색어 입력 중(연관 검색어) 화면으로.
+        // inputText(검색어)는 유지하고, 제출된 검색어만 비워 related 모드로 전환한다.
+        setSearchText("");
+        setIsSearching(true);
+      }
     },
     onSearch: handleSearch,
     onFocus: () => setIsSearching(true),
@@ -354,7 +359,7 @@ export default function PhotoFeedSearchPage() {
   return (
     <div className="relative min-h-dvh w-full flex-col">
       {/* SearchBar */}
-      <div className="mt-3 mb-5">
+      <div className="sticky top-0 z-50 bg-neutral-900 pt-3 pb-5">
         <SearchBar {...searchBarProps} />
       </div>
 

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -297,7 +297,7 @@ export default function PhotoFeedSearchPage() {
     if (isSearchError) return errorResponse();
 
     return (
-      <div className="mt-4 flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <h2 className="text-[1rem] leading-[155%] font-semibold tracking-[-0.02em] text-neutral-100">

--- a/src/pages/photoFeed/PostPage.tsx
+++ b/src/pages/photoFeed/PostPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/assets/icon";
 import { Header, ToastItem } from "@/components/common";
 import PhotoCarousel from "@/components/photoFeed/postDetail/PhotoCarousel";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useLocation } from "react-router";
 import { usePostDetail, useUnlikePost, useLikePost } from "@/hooks/photoFeed";
 import Profile from "@/components/photoFeed/postDetail/Profile";
@@ -54,6 +54,10 @@ export default function PostPage() {
   // 게시글 등록 직후인지 여부
   const isNewPost = useNewPostState((s) => s.isNewPost);
 
+  // 이 뷰가 "등록 직후" 진입인지 최초 마운트 시점에 고정한다.
+  // (토스트 타이머로 isNewPost가 false가 되어도 뒤로가기는 피드로 가야 하므로)
+  const cameFromNewPostRef = useRef(isNewPost);
+
   const [toastVisible, setToastVisible] = useState(isNewPost);
   const [mounted, setMounted] = useState(isNewPost);
 
@@ -79,7 +83,7 @@ export default function PostPage() {
   }, [isNewPost]);
 
   const handleGoBack = () => {
-    if (isNewPost) {
+    if (cameFromNewPostRef.current) {
       setIsNewPost(false);
       return navigate("/photoFeed");
     }
@@ -93,7 +97,12 @@ export default function PostPage() {
       return (
         <>
           <div className="flex animate-pulse flex-col gap-[0.625rem] pb-10">
-            <Header title="" showBack onBack={handleGoBack} />
+            <Header
+              title=""
+              showBack
+              onBack={handleGoBack}
+              className="sticky top-0 z-50 bg-neutral-900"
+            />
             <ProfileSkeleton />
             <div className="h-90 w-full bg-neutral-700"></div>
             <p className="h-4 w-70 rounded-xl bg-neutral-800"></p>
@@ -105,7 +114,12 @@ export default function PostPage() {
     if (isPostError)
       return (
         <div className="flex h-full flex-col">
-          <Header title="" showBack onBack={handleGoBack} />
+          <Header
+            title=""
+            showBack
+            onBack={handleGoBack}
+            className="sticky top-0 z-50 bg-neutral-900"
+          />
           <div className="flex flex-1 items-center justify-center">
             <p className="text-red-400">불러오기에 실패했어요.</p>
           </div>
@@ -114,7 +128,12 @@ export default function PostPage() {
     if (!postDetail) return <EmptyView content="게시글 정보가 없습니다." />;
     return (
       <>
-        <Header title="" showBack onBack={handleGoBack} />
+        <Header
+          title=""
+          showBack
+          onBack={handleGoBack}
+          className="sticky top-0 z-50 bg-neutral-900"
+        />
         <section className="flex flex-col gap-[0.625rem] pb-10">
           {/** 상단 */}
           <div className="flex flex-col gap-4">

--- a/src/pages/photoFeed/PostPage.tsx
+++ b/src/pages/photoFeed/PostPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/assets/icon";
 import { Header, ToastItem } from "@/components/common";
 import PhotoCarousel from "@/components/photoFeed/postDetail/PhotoCarousel";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams, useLocation } from "react-router";
 import { usePostDetail, useUnlikePost, useLikePost } from "@/hooks/photoFeed";
 import Profile from "@/components/photoFeed/postDetail/Profile";
@@ -51,18 +51,17 @@ export default function PostPage() {
 
   const isMutating = isLiking || isUnliking;
 
-  // 게시글 등록 직후인지 여부
-  const isNewPost = useNewPostState((s) => s.isNewPost);
+  // 게시글 등록한 직후인지에 대한 정보 저장 setter
+  const setIsNewPost = useNewPostState((s) => s.setIsNewPost);
 
-  // 이 뷰가 "등록 직후" 진입인지 최초 마운트 시점에 고정한다.
-  // (토스트 타이머로 isNewPost가 false가 되어도 뒤로가기는 피드로 가야 하므로)
-  const cameFromNewPostRef = useRef(isNewPost);
+  // 최초 마운트 시점의 isNewPost를 로컬로 "고정"한다.
+  // 스토어를 구독/직접 읽으면, 아래 언마운트 리셋(setIsNewPost(false))이
+  // 개발모드 StrictMode의 팬텀 언마운트 때 실행되면서 false가 되어
+  // 토스트가 사라지고 뒤로가기가 피드가 아닌 이전 단계로 가버린다.
+  const [isNewPost] = useState(() => useNewPostState.getState().isNewPost);
 
   const [toastVisible, setToastVisible] = useState(isNewPost);
   const [mounted, setMounted] = useState(isNewPost);
-
-  // 게시글 등록한 직후인지에 대한 정보 저장
-  const setIsNewPost = useNewPostState((s) => s.setIsNewPost);
 
   useEffect(() => {
     if (!isNewPost) return;
@@ -71,8 +70,9 @@ export default function PostPage() {
       () => setToastVisible(false),
       TOAST_FADE_START_DELAY,
     );
+    // 토스트만 숨기고 isNewPost는 유지한다.
+    // (여기서 false로 바꾸면 3초 뒤 하드웨어 뒤로가기가 피드가 아닌 이전 단계로 감)
     const removeTimer = setTimeout(() => {
-      setIsNewPost(false);
       setMounted(false);
     }, TOAST_UNMOUNT_DELAY);
 
@@ -82,9 +82,17 @@ export default function PostPage() {
     };
   }, [isNewPost]);
 
-  const handleGoBack = () => {
-    if (cameFromNewPostRef.current) {
+  // 페이지를 벗어날 때(언마운트) 등록 직후 상태를 초기화한다.
+  // 화면에 머무는 동안 isNewPost가 유지되므로 헤더/하드웨어 뒤로가기 모두 피드로 간다.
+  useEffect(() => {
+    return () => {
       setIsNewPost(false);
+    };
+  }, [setIsNewPost]);
+
+  const handleGoBack = () => {
+    // 등록 직후 진입이면 항상 피드로 (isNewPost는 언마운트 시 초기화됨)
+    if (isNewPost) {
       return navigate("/photoFeed");
     }
     // 히스토리 없으면 fallback

--- a/src/pages/photoFeed/ReviewPhotoLabPage.tsx
+++ b/src/pages/photoFeed/ReviewPhotoLabPage.tsx
@@ -132,6 +132,7 @@ export default function ReviewPhotoLabPage() {
             }
             maxLength={MAX}
             minLength={MIN}
+            enforceMaxLength={false}
             isError={reviewTextError}
           />
           {reviewTextError && (

--- a/src/pages/photoFeed/ReviewPhotoLabPage.tsx
+++ b/src/pages/photoFeed/ReviewPhotoLabPage.tsx
@@ -88,7 +88,10 @@ export default function ReviewPhotoLabPage() {
         reviewContent: reviewText,
       });
     } catch (e) {
-      console.error("게시글 업로드 실패", e); // TODO 디자인 받고 토스트 메세지로 변경
+      // Android logcat은 객체를 그대로 넘기면 [object Object]로만 찍히므로 문자열화해서 남긴다.
+      console.error(
+        "게시글 업로드 실패: " + (e instanceof Error ? e.message : String(e)),
+      ); // TODO 디자인 받고 토스트 메세지로 변경
     }
   };
 

--- a/src/pages/photoFeed/ReviewPhotoLabPage.tsx
+++ b/src/pages/photoFeed/ReviewPhotoLabPage.tsx
@@ -133,15 +133,20 @@ export default function ReviewPhotoLabPage() {
             maxLength={MAX}
             minLength={MIN}
             enforceMaxLength={false}
+            emptyHint={"max"}
             isError={reviewTextError}
           />
-          {reviewTextError && (
+          {reviewText.length > MAX ? (
+            <p className="px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
+              최대 {MAX}자까지 입력 가능합니다.
+            </p>
+          ) : reviewTextError ? (
             <p
               className={`px-[0.625rem] text-[0.875rem] font-normal text-orange-500`}
             >
               최소 20글자 이상 입력해주세요.
             </p>
-          )}
+          ) : null}
         </div>
 
         <div className="bg-neutral-875 flex justify-center gap-2 rounded-2xl p-[1.25rem] text-neutral-500">

--- a/src/pages/photoFeed/ReviewPhotoLabPage.tsx
+++ b/src/pages/photoFeed/ReviewPhotoLabPage.tsx
@@ -96,8 +96,13 @@ export default function ReviewPhotoLabPage() {
   };
 
   return (
-    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] py-[1rem]">
-      <Header title="현상소 리뷰 작성" showBack onBack={() => navigate(-1)} />
+    <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
+      <Header
+        title="현상소 리뷰 작성"
+        showBack
+        onBack={() => navigate(-1)}
+        className="sticky top-0 z-50 bg-neutral-900"
+      />
       <section className="flex flex-col gap-6 pt-10 pb-10">
         <div className="flex flex-col gap-2">
           <h1 className="text-left text-[1.375rem] font-semibold text-white">


### PR DESCRIPTION
## 🔀 Pull Request Title

사진수다 v2 QA 2차 수정사항 반영 

- Closes #322 

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

1. 헤더 / 네비게이션 
- [x] 사진수다(photoFeed) 모든 페이지 헤더 스크롤 시 고정 수정 (메인피드·글작성·현상소입력·리뷰·게시글상세·검색)
- [x] 글작성/현상소 페이지 헤더 위 여백 제거 + 스크롤 시 안 움직이게 수정 (메인피드처럼 딱 고정)
- [x] 검색 결과에서 뒤로가기 → 연관검색어 화면(검색어·연관어 유지)으로 이동 수정
- [x] 글 작성 페이지에서 뒤로가기 → 네이티브 갤러리 다시 열기 수정
- [x] 게시글 등록 직후 뷰에서 뒤로가기 → 항상 메인 피드로 이동 수정 (토스트 사라진 뒤에도 유지)

2. 게시글 작성 
- [x] 제목/본문 글자수 초과 시 입력 막지 않고, 테두리+카운터 빨간색 표시 수정
- [x] 초과 시 "최대 N자까지 입력 가능합니다" 메시지 표시 수정 (다른 페이지 하드캡은 그대로 유지)

3. 프로필 / 신고 / 공유
- [x] 프로필 이미지 로드 실패(깨짐) 시 기본 아이콘으로 폴백 수정
- [x] 게시글/댓글 신고 기능 추가 (사유 선택 팝업 → /reports 호출 → "신고가 완료되었습니다" 토스트)
- [x] 타인 게시글/댓글 ... 메뉴: 공유하기 + 신고하기 수정
- [x] 자기 게시글/댓글 ... 메뉴: 공유하기 + 삭제하기 수정 (내 댓글에 공유하기 추가)