### PR TITLE
[REFACTOR]V2 2차 QA 대응

### DIFF
--- a/src/hooks/auth/onBoarding/useOnBoardingForm.ts
+++ b/src/hooks/auth/onBoarding/useOnBoardingForm.ts
@@ -158,8 +158,8 @@ export function useOnBoardingForm(options?: Options) {
         setIsVerified(false);
         setVerifiedPhoneToken(null);
 
-        setPhoneVerifyMessage("인증번호를 재발송해주세요.");
-        setPhoneVerifyError("인증번호가 올바르지 않습니다.");
+        setPhoneVerifyMessage("");
+        setPhoneVerifyError("인증번호를 재발송해주세요.");
       },
     });
 

--- a/src/hooks/photoLab/useFavoriteToggle.ts
+++ b/src/hooks/photoLab/useFavoriteToggle.ts
@@ -114,10 +114,10 @@ export function useFavoriteToggle() {
 
     onSettled: (_data, _err, { photoLabId }) => {
       queryClient.invalidateQueries({ queryKey: LIST_KEY });
-      // 화면에 떠 있는 동안 즉시 재조회해 항목이 사라지지 않도록 inactive로만 무효화
+      // 화면에 떠 있는 동안 즉시 재조회되어 항목이 사라지지 않도록 stale 마킹만 수행 (진입 시 재조회)
       queryClient.invalidateQueries({
         queryKey: FAVORITES_KEY,
-        refetchType: "inactive",
+        refetchType: "none",
       });
       queryClient.invalidateQueries({
         queryKey: ["photoLab", "detail", photoLabId],

--- a/src/hooks/photoLab/useFavoriteToggle.ts
+++ b/src/hooks/photoLab/useFavoriteToggle.ts
@@ -114,10 +114,15 @@ export function useFavoriteToggle() {
 
     onSettled: (_data, _err, { photoLabId }) => {
       queryClient.invalidateQueries({ queryKey: LIST_KEY });
-      queryClient.invalidateQueries({ queryKey: FAVORITES_KEY });
+      // 화면에 떠 있는 동안 즉시 재조회해 항목이 사라지지 않도록 inactive로만 무효화
+      queryClient.invalidateQueries({
+        queryKey: FAVORITES_KEY,
+        refetchType: "inactive",
+      });
       queryClient.invalidateQueries({
         queryKey: ["photoLab", "detail", photoLabId],
       });
     },
+    //
   });
 }

--- a/src/pages/mypage/edit-info/EditInfoPage.tsx
+++ b/src/pages/mypage/edit-info/EditInfoPage.tsx
@@ -31,11 +31,12 @@ export function EditInfoPage() {
   }, [me?.member?.phone]);
 
   const socialAccount = me?.roleData?.user?.socialAccounts?.[0];
-  const socialProviderLabel = useMemo(() => {
-    if (socialAccount?.provider === "KAKAO") return "카카오톡";
-    if (socialAccount?.provider === "APPLE") return "Apple";
-    return socialAccount?.provider ?? "";
-  }, [socialAccount?.provider]);
+  const socialProviderLabel =
+    socialAccount?.provider === "KAKAO"
+      ? "카카오톡"
+      : socialAccount?.provider === "APPLE"
+        ? "Apple"
+        : (socialAccount?.provider ?? "");
 
   const maxSizeMB = 5;
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/src/pages/mypage/edit-info/EditInfoPage.tsx
+++ b/src/pages/mypage/edit-info/EditInfoPage.tsx
@@ -30,6 +30,13 @@ export function EditInfoPage() {
     return raw ? formatPhoneKorea(raw) : "";
   }, [me?.member?.phone]);
 
+  const socialAccount = me?.roleData?.user?.socialAccounts?.[0];
+  const socialProviderLabel = useMemo(() => {
+    if (socialAccount?.provider === "KAKAO") return "카카오톡";
+    if (socialAccount?.provider === "APPLE") return "Apple";
+    return socialAccount?.provider ?? "";
+  }, [socialAccount?.provider]);
+
   const maxSizeMB = 5;
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -295,7 +302,7 @@ export function EditInfoPage() {
         <OptionLink
           to="./social"
           text="연동된 소셜 계정"
-          info="카카오톡"
+          info={socialProviderLabel}
           infoColor="gray"
         />
 


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: 인증/로그인/좋아요 QA 반영 (#332)

- Closes #332

<br>

## 🎞️ 주요 코드 설명

### 관심현상소 좋아요 해제 시 목록에서 즉시 사라지는 문제

- `useFavoriteToggle`의 `onMutate`에서 이미 낙관적 업데이트로 캐시를 최신 상태로 반영하고 있었는데, `onSettled`에서 `FAVORITES_KEY`를 즉시 `invalidateQueries` 하면서 화면에 떠 있는 마이페이지 관심현상소 목록이 바로 서버 재조회되어 해제한 항목이 사라지고, 그 자리에서 바로 재등록할 수 없었음
- `refetchType: "inactive"`로 변경해 현재 보고 있는 화면은 낙관적 업데이트 상태를 유지하고, 다음에 그 화면에 재진입할 때만 최신 데이터로 갱신되도록 수정

### 인증번호 만료 시 재발송 안내 문구 미노출

- `confirmCode`의 `onError`에서 `phoneVerifyMessage`("인증번호를 재발송해주세요.")와 `phoneVerifyError`("인증번호가 올바르지 않습니다.")를 동시에 세팅했는데, 화면에는 `phoneVerifyError`가 우선 노출되도록 되어 있어 인증 시간이 만료된 경우에도 항상 "인증번호가 올바르지 않습니다."만 보이던 문제
- `phoneVerifyError`에 "인증번호를 재발송해주세요." 문구를 직접 세팅하도록 수정

### 마이페이지 연동 소셜 계정 표시 하드코딩

- 마이페이지 정보수정 화면에서 연동된 소셜 계정이 로그인 방식과 무관하게 항상 "카카오톡"으로 하드코딩되어 있던 문제
- `me.roleData.user.socialAccounts[0].provider` 값에 따라 카카오톡/Apple로 분기해서 표시하도록 수정

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] 관심현상소 좋아요 해제/등록 시 마이페이지 목록에서 항목이 즉시 사라지는 문제 수정
- [x] 인증번호 만료 시 "인증번호를 재발송해주세요." 안내 문구가 정상 노출되도록 수정
- [x] 마이페이지 연동된 소셜 계정 표시를 로그인 방식(카카오톡/Apple)에 맞게 동적으로 표시하도록 수정

<br>