### PR TITLE
[FIX] 배송지 addressId 타입 number→string (#342)

### DIFF
--- a/src/pages/photoManage/SelectAddressPage.tsx
+++ b/src/pages/photoManage/SelectAddressPage.tsx
@@ -8,7 +8,7 @@ import { usePrintOrderStore } from "@/store/usePrintOrder.store";
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
-type LocationState = { selectedAddressId?: number } | null;
+type LocationState = { selectedAddressId?: string } | null;
 
 export function SelectAddressPage() {
   const navigate = useNavigate();

--- a/src/store/useAddressId.store.ts
+++ b/src/store/useAddressId.store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 
 type PrintOrderState = {
-  selectedAddressId: number | null;
-  setSelectedAddressId: (id: number | null) => void;
+  selectedAddressId: string | null;
+  setSelectedAddressId: (id: string | null) => void;
 };
 
 export const useAddressIdStore = create<PrintOrderState>()((set) => ({

--- a/src/types/photomanage/address.ts
+++ b/src/types/photomanage/address.ts
@@ -1,6 +1,6 @@
 // 배송지 조회 응답 (GET /users/addresses)
 export type Address = {
-  addressId: number;
+  addressId: string;
   addressName: string;
   zipcode: string;
   address: string;


### PR DESCRIPTION
## 🔀 Pull Request Title
[FIX] 배송지 addressId 타입 number→string (#342)

## 🎞️ 주요 코드 설명

### Address.addressId number → string
BE `GET/POST /users/addresses` 응답의 `addressId`는 `@Tsid Long`이라 TSID 문자열(예: "0QX09V7ZKXHC6")로 내려옵니다. FE 타입만 number로 선언되어 있어 계약 드리프트 상태였고, `Number()` 변환이 추가되는 순간 2^53 초과 정밀도 손실(NaN/반올림) 버그가 되는 구조라 string으로 통일했습니다. (신고/문의 어드민 NaN 사고와 동일 계열 — TSID 전수조사에서 발견)

### 연쇄 타입 정리
- `useAddressIdStore.selectedAddressId`: number|null → string|null
- `SelectAddressPage` LocationState.selectedAddressId: number → string

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.
- 배송지 도메인의 addressId 타입을 BE TSID 계약에 맞게 string으로 수정 (런타임 동작 변화 없음 — 기존에도 문자열이 흘렀고 비교는 string===string)
- `pnpm build`(tsc -b + vite) 통과 확인

## 📷 스크린샷
타입 수정만 있어 UI 변화 없음

Closes #342