### PR TITLE
[FIX] 메인 페이지 좌우 margin에서 스크롤 안 되는 문제 수정

### DIFF
--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -55,7 +55,7 @@ export default function MainPage() {
       <Header />
       <div
         ref={scrollRef}
-        className="scrollbar-hide ml-[calc(50%-50vw)] w-screen flex-1 overflow-x-hidden overflow-y-auto pb-(--tabbar-height)"
+        className="scrollbar-hide relative ml-[calc(50%-50vw)] w-screen flex-1 overflow-x-hidden overflow-y-auto pb-(--tabbar-height)"
       >
         <SectionWrapper id="promotion">
           <PromotionBanner />

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -14,7 +14,11 @@ const SectionWrapper = ({
 }: {
   id: string;
   children: React.ReactNode;
-}) => <div data-anchor={id}>{children}</div>;
+}) => (
+  <div data-anchor={id} className="mx-auto w-full max-w-sm">
+    {children}
+  </div>
+);
 
 export default function MainPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -51,7 +55,7 @@ export default function MainPage() {
       <Header />
       <div
         ref={scrollRef}
-        className="scrollbar-hide flex-1 overflow-y-auto pb-(--tabbar-height)"
+        className="scrollbar-hide ml-[calc(50%-50vw)] w-screen flex-1 overflow-x-hidden overflow-y-auto pb-(--tabbar-height)"
       >
         <SectionWrapper id="promotion">
           <PromotionBanner />
@@ -65,7 +69,9 @@ export default function MainPage() {
         <SectionWrapper id="community">
           <CommunityGallerySection />
         </SectionWrapper>
-        <Footer />
+        <div className="mx-auto w-full max-w-sm">
+          <Footer />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: 메인 페이지 좌우 margin에서 스크롤 안 되는 문제 수정

- Closes #347

<br>

## 📌 PR 설명

- [x] 메인 페이지에서 좌우 margin(넓은 뷰포트에서 중앙 컬럼 바깥 여백) 위에 커서/터치가 있을 때 세로 스크롤이 안 되던 문제 수정
- [x] 스크롤 위치 복원(`useAnchorScroll`)에 쓰이는 직계 자식 DOM 구조는 그대로 유지