### PR TITLE
[FEAT] 앱 OS 네이티브 기능 관련 UX 개선

### DIFF
--- a/ios/App/App/MainViewController.swift
+++ b/ios/App/App/MainViewController.swift
@@ -6,5 +6,8 @@ class MainViewController: CAPBridgeViewController {
 
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(FindersBillingPlugin())
+
+        // 엣지 스와이프 뒤로가기 — SPA(pushState) 히스토리에도 동작
+        webView?.allowsBackForwardNavigationGestures = true
     }
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,18 +1,26 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, Outlet } from "react-router";
 import { App } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";
 import GlobalLoginDialog from "@/components/common/GlobalLoginDialog";
+import { DialogBox } from "@/components/common/DialogBox";
 import { useNewPostState } from "@/store/useNewPostState.store";
 
 export default function RootLayout() {
   const navigate = useNavigate();
+  const [exitDialogOpen, setExitDialogOpen] = useState(false);
 
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
 
     // Promise 자체를 붙잡아, resolve 타이밍과 무관하게 클린업에서 리스너를 제거한다.
     const handlePromise = App.addListener("backButton", ({ canGoBack }) => {
+      // 종료 다이얼로그가 떠 있으면 뒤로가기로 닫기만 한다
+      if (exitDialogOpen) {
+        setExitDialogOpen(false);
+        return;
+      }
+
       // 게시글 등록 직후엔 하드웨어 뒤로가기도 이전 작성 단계가 아니라 피드로 이동
       if (useNewPostState.getState().isNewPost) {
         useNewPostState.getState().setIsNewPost(false);
@@ -23,18 +31,26 @@ export default function RootLayout() {
       if (canGoBack) {
         navigate(-1);
       } else {
-        App.exitApp();
+        setExitDialogOpen(true);
       }
     });
 
     return () => {
       handlePromise.then((handle) => handle.remove());
     };
-  }, [navigate]);
+  }, [navigate, exitDialogOpen]);
 
   return (
     <div className="min-h-dvh w-full bg-neutral-900 text-neutral-100">
       <GlobalLoginDialog />
+      <DialogBox
+        isOpen={exitDialogOpen}
+        title="앱을 종료하시겠어요?"
+        confirmText="종료"
+        cancelText="취소"
+        onConfirm={() => App.exitApp()}
+        onCancel={() => setExitDialogOpen(false)}
+      />
       {/* safe-area + 중앙 레이아웃(PC) + 패딩(모바일) */}
       <div className="mx-auto flex min-h-dvh w-full max-w-120 flex-col px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:px-6 lg:px-8">
         {/* Rootlayout으로 감싸진 모든 컴포넌트 렌더링*/}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -267,7 +267,8 @@ const router = createBrowserRouter([
   {
     Component: RootLayout,
     children: [
-      { index: true, element: <Navigate to="/auth/login" /> },
+      // replace가 아니면 히스토리에 "/"가 남아 Android 뒤로가기로 앱이 안 닫힘
+      { index: true, element: <Navigate to="/auth/login" replace /> },
 
       // auth prefix를 한 번만
       { path: "auth", children: authRoutes },


### PR DESCRIPTION
## 🔀 Pull Request Title

iOS와 Android에서 네이티브로 지원하는 기능에 대한 지원을 추가하여 UX 향상

- Closes #349 
<br>

## 🎞️ 주요 코드 설명 <!-- 코드 설명 필요 없을 시 생략! -->

###  iOS 엣지 스와이프 뒤로가기 제스처 활성화

```
        // 엣지 스와이프 뒤로가기 — SPA(pushState) 히스토리에도 동작
        webView?.allowsBackForwardNavigationGestures = true
```


## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] iOS 제스처로 뒤로가기
- [x] Android 뒤로가기 기능으로 앱 닫기

<br>

## 📷 스크린샷

<img width="411" height="915" alt="image" src="https://github.com/user-attachments/assets/6dcbe451-63a5-4992-961c-d12827a3244a" />



<br>
