### PR TITLE
[CHORE] Android release 빌드 보안 강화(#352)

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -66,7 +66,7 @@ keystore.properties
 .cxx/
 
 # Google Services (e.g. APIs or Firebase)
-# google-services.json
+google-services.json
 
 # Freeline
 freeline.py

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,7 +36,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release


### PR DESCRIPTION
## 🔀 Pull Request Title

chore: Android release 빌드 보안 강화 - minify/gitignore(#352)

- Closes #352

<br>

## 🎞️ 주요 코드 설명

### android/app/build.gradle

- release 빌드타입에 `minifyEnabled true`, `shrinkResources true` 추가 (기존엔 꺼져 있어서 R8 난독화/리소스 축소 없이 배포되던 상태)

### android/.gitignore

- `google-services.json` gitignore 처리 (기존엔 주석 처리돼 있어 실수로 커밋될 수 있는 상태였음)

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] JDK 21(Android Studio 번들 JBR)로 `gradlew assembleRelease` 성공 확인 — R8 포함 unsigned release APK 정상 생성 (컴파일 타임 검증)
- [x] proguard-rules.pro가 비어있음에도 Capacitor 플러그인/Kakao SDK가 각자 consumer proguard 규칙을 AAR에 번들하고 있어 별도 keep 규칙 추가 없이 빌드 통과 확인

<br>

## ⚠️ 판단이 필요한 부분 (리뷰 시 확인 요청)

1. **런타임 검증 필요**: 이번 확인은 빌드 타임(R8 컴파일 성공)까지만이고, 실제 서명된 APK를 실기기에 설치해서 카카오 로그인/FCM 등 리플렉션 의존 기능이 난독화 후에도 정상 동작하는지는 별도로 확인 필요.
2. **GCP 콘솔 API 키 제한 미확인 상태로 보류**: `google-services.json`의 Firebase API 키가 `com.finders` 패키지명 + release 서명 SHA-1로 제한돼 있는지 콘솔 접근 권한이 없어 확인 못 함 — 직접 확인 필요.
3. **allowBackup 정책은 이번 PR 범위에서 제외**: 팀 논의 후 별도 이슈로 진행하기로 함.

<br>

## 📷 스크린샷

UI 변경 없음 (생략)