### PR TITLE
[FIX] 사진수다 헤더 고정 및 토스트/빈화면 QA 반영 (#358)

### DIFF
--- a/src/pages/photoFeed/FindPhotoLabPage.tsx
+++ b/src/pages/photoFeed/FindPhotoLabPage.tsx
@@ -245,8 +245,9 @@ export default function FindPhotoLabPage() {
 
   return (
     <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
-      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응) */}
-      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응)
+          z-30: 검색 컨테이너(z-20)보다 위여야 검색 결과가 헤더를 덮지 않는다 */}
+      <div className="sticky top-0 z-30 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
         <Header title="현상소 입력하기" showBack onBack={handleGoBack} />
       </div>
 

--- a/src/pages/photoFeed/FindPhotoLabPage.tsx
+++ b/src/pages/photoFeed/FindPhotoLabPage.tsx
@@ -180,7 +180,13 @@ export default function FindPhotoLabPage() {
       return <ErrorState />;
     }
     if (!data || data.length === 0) {
-      return <EmptyView />;
+      // EmptyView는 absolute inset-0라, 높이를 가진 relative 컨테이너로 감싸
+      // 검색창 아래 영역에서 중앙정렬되게 한다 (검색창과 겹침 방지)
+      return (
+        <div className="relative min-h-[50dvh]">
+          <EmptyView />
+        </div>
+      );
     }
     return (
       <ul className="divide-y divide-neutral-800 px-4">
@@ -239,12 +245,10 @@ export default function FindPhotoLabPage() {
 
   return (
     <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
-      <Header
-        title="현상소 입력하기"
-        showBack
-        onBack={handleGoBack}
-        className="sticky top-0 z-50 bg-neutral-900"
-      />
+      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응) */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+        <Header title="현상소 입력하기" showBack onBack={handleGoBack} />
+      </div>
 
       {/* 검색모드일 때: 화면 전체 클릭을 감지하는 투명 오버레이 */}
       {labReviewStep === "search" && (

--- a/src/pages/photoFeed/NewPostPage.tsx
+++ b/src/pages/photoFeed/NewPostPage.tsx
@@ -10,7 +10,7 @@ import { scrollToCenter } from "@/utils/scrollToCenter";
 const LIMITS = {
   titleMin: 2,
   titleMax: 30,
-  contentMin: 20,
+  contentMin: 0,
   contentMax: 300,
   maxPhotos: 10,
 } as const;
@@ -121,15 +121,17 @@ export default function NewPostPage() {
           await useNewPostState.getState().setFiles(picked);
         }}
       />
-      <Header
-        title="글 작성하기"
-        showBack
-        onBack={() => {
-          // 헤더 뒤로가기 → 네이티브 갤러리를 다시 연다.
-          galleryInputRef.current?.click();
-        }}
-        className="sticky top-0 z-50 bg-neutral-900"
-      />
+      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응) */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+        <Header
+          title="글 작성하기"
+          showBack
+          onBack={() => {
+            // 헤더 뒤로가기 → 네이티브 갤러리를 다시 연다.
+            galleryInputRef.current?.click();
+          }}
+        />
+      </div>
       {/* 선택된 사진 슬라이딩 */}
       <div
         className="scrollbar-hide mb-[1rem] flex h-[15.1875rem] snap-x snap-mandatory gap-[0.5rem] overflow-x-auto p-[1rem] [-webkit-overflow-scrolling:touch]"
@@ -201,7 +203,6 @@ export default function NewPostPage() {
               }
             }}
             placeholder="나만의 필름 사진 이야기를 공유해주세요."
-            minLength={LIMITS.contentMin}
             maxLength={LIMITS.contentMax}
             enforceMaxLength={false}
             isError={contentError}
@@ -213,7 +214,7 @@ export default function NewPostPage() {
             </p>
           ) : contentError ? (
             <p className="t-error-in px-[0.625rem] text-[0.875rem] font-normal text-orange-500">
-              최소 20글자 이상 입력해주세요.
+              내용을 입력해주세요.
             </p>
           ) : null}
         </section>

--- a/src/pages/photoFeed/PhotoFeedPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedPage.tsx
@@ -79,17 +79,19 @@ export default function PhotoFeedPage() {
 
   return (
     <main className="mx-auto w-full max-w-6xl pb-6">
-      <Header
-        title="사진수다"
-        rightAction={{
-          type: "icon",
-          icon: <SearchIcon className="h-4.5 w-4.5 text-neutral-200" />,
-          onClick: () => {
-            navigate("/photoFeed/search");
-          },
-        }}
-        className="sticky top-0 z-50 bg-neutral-900"
-      />
+      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응) */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+        <Header
+          title="사진수다"
+          rightAction={{
+            type: "icon",
+            icon: <SearchIcon className="h-4.5 w-4.5 text-neutral-200" />,
+            onClick: () => {
+              navigate("/photoFeed/search");
+            },
+          }}
+        />
+      </div>
 
       {/* 에러 처리 */}
       {isError && <ErrorState />}

--- a/src/pages/photoFeed/PhotoFeedSearchPage.tsx
+++ b/src/pages/photoFeed/PhotoFeedSearchPage.tsx
@@ -380,8 +380,8 @@ export default function PhotoFeedSearchPage() {
 
   return (
     <div className="relative min-h-dvh w-full flex-col">
-      {/* SearchBar */}
-      <div className="sticky top-0 z-50 bg-neutral-900 pt-3 pb-5">
+      {/* SearchBar (스크롤 시에도 상단 고정, safe-area 대응) */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[calc(env(safe-area-inset-top)+0.75rem)] pb-5">
         <SearchBar {...searchBarProps} />
       </div>
 

--- a/src/pages/photoFeed/PostPage.tsx
+++ b/src/pages/photoFeed/PostPage.tsx
@@ -91,12 +91,9 @@ export default function PostPage() {
       return (
         <>
           <div className="t-skel-sheen flex flex-col gap-[0.625rem] pb-10">
-            <Header
-              title=""
-              showBack
-              onBack={handleGoBack}
-              className="sticky top-0 z-50 bg-neutral-900"
-            />
+            <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+              <Header title="" showBack onBack={handleGoBack} />
+            </div>
             <ProfileSkeleton />
             <div className="h-90 w-full bg-neutral-700"></div>
             <p className="h-4 w-70 rounded-xl bg-neutral-800"></p>
@@ -108,24 +105,18 @@ export default function PostPage() {
     if (isPostError)
       return (
         <div className="flex h-full flex-col">
-          <Header
-            title=""
-            showBack
-            onBack={handleGoBack}
-            className="sticky top-0 z-50 bg-neutral-900"
-          />
+          <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+            <Header title="" showBack onBack={handleGoBack} />
+          </div>
           <ErrorState className="flex flex-1 items-center justify-center" />
         </div>
       );
     if (!postDetail) return <EmptyView content="게시글 정보가 없습니다." />;
     return (
       <>
-        <Header
-          title=""
-          showBack
-          onBack={handleGoBack}
-          className="sticky top-0 z-50 bg-neutral-900"
-        />
+        <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+          <Header title="" showBack onBack={handleGoBack} />
+        </div>
         <section className="flex flex-col gap-[0.625rem] pb-10">
           {/** 상단 */}
           <div className="flex flex-col gap-4">

--- a/src/pages/photoFeed/ReviewPhotoLabPage.tsx
+++ b/src/pages/photoFeed/ReviewPhotoLabPage.tsx
@@ -100,12 +100,10 @@ export default function ReviewPhotoLabPage() {
 
   return (
     <div className="mx-auto min-h-dvh w-full max-w-[23.4375rem] pb-[1rem]">
-      <Header
-        title="현상소 리뷰 작성"
-        showBack
-        onBack={() => navigate(-1)}
-        className="sticky top-0 z-50 bg-neutral-900"
-      />
+      {/* 헤더 (스크롤 시에도 상단 고정, safe-area 대응) */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-[env(safe-area-inset-top)] bg-neutral-900 px-4 pt-[env(safe-area-inset-top)]">
+        <Header title="현상소 리뷰 작성" showBack onBack={() => navigate(-1)} />
+      </div>
       <section className="flex flex-col gap-6 pt-10 pb-10">
         <div className="flex flex-col gap-2">
           <h1 className="text-left text-[1.375rem] font-semibold text-white">


### PR DESCRIPTION
## 🔀 Pull Request Title

사진수다 헤더 고정 및 토스트/빈화면 QA 반영

- Closes #358 

<br>


## 📌 PR 설명


- 헤더 스크롤 고정: 모든 photoFeed 페이지 헤더를 photoLab의 safe-area 대응 sticky 래퍼 방식으로 통일 (모바일에서 고정 안 되던 문제 해결)
- 게시글 삭제 토스트: 라우터 state를 즉시 비워 다른 글 갔다 뒤로가기 시 토스트가 재발생하던 버그 수정
- 게시글 등록 직후 뒤로가기/토스트: isNewPost를 마운트 시점에 로컬 고정해 StrictMode 팬텀 언마운트로 토스트 미표시·뒤로가기 오작동하던 문제 수정
- 현상소 검색 결과 없을 때 EmptyView가 검색창과 겹치던 위치 수정
- 본문 최소 글자수 제거 대응: 빈 본문 안내 메시지 추가