### PR TITLE
[FIX] Android release 빌드 크래시 및 FCM 알림 미표시 수정(#361, #362)

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -66,7 +66,10 @@ keystore.properties
 .cxx/
 
 # Google Services (e.g. APIs or Firebase)
-google-services.json
+# google-services.json은 비밀정보가 아니다(API 키는 패키지명+SHA-1로 제한됨).
+# 무시하면 다른 머신·CI에서 google-services 플러그인이 조용히 미적용되어
+# Firebase 리소스 없는 APK가 나오고 푸시가 에러 없이 죽는다(#361).
+# google-services.json
 
 # Freeline
 freeline.py

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "266626418049",
+    "project_id": "finders-firebase",
+    "storage_bucket": "finders-firebase.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:266626418049:android:97d15cca1a967db201d480",
+        "android_client_info": {
+          "package_name": "com.finders"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBLFOVwkDrk0p_PjsTzt1WsTygQnoPDyUI"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Kakao SDK는 모델을 kotlinx.serialization으로 다루는데 KakaoJson이 serializer를
+# 리플렉션으로 찾는다. R8은 그 참조를 못 봐서 컴파일 시 생성된 $$serializer/Companion을
+# 통째로 지우고, 저장된 토큰을 읽는 순간 SerializationException이 난다(#361).
+# SDK의 consumer 룰은 액티비티만 keep한다. 2.23.0 기준 @Serializable 클래스는
+# 전부 *.model 패키지 안에 있다(auth/common/share/template/user).
+-keep class com.kakao.sdk.**.model.* { <fields>; }

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_background.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<inset xmlns:android="http://schemas.android.com/apk/res/android"
-    android:drawable="@mipmap/ic_launcher_background"
-    android:inset="16.7%" />

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_foreground.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<inset xmlns:android="http://schemas.android.com/apk/res/android"
-    android:drawable="@mipmap/ic_launcher_foreground"
-    android:inset="16.7%" />


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: Android release 빌드 크래시 및 FCM 알림 미표시 수정

- Closes #361
- Closes #362

<br>

## 🎞️ 주요 코드 설명

### 1. R8이 Kakao SDK serializer를 제거해 첫 화면에서 앱이 종료되던 문제 (#361)

#352에서 `minifyEnabled true`를 켠 뒤 R8이 Kakao SDK의 kotlinx.serialization 생성 클래스(`$$serializer` / `Companion`)를 통째로 제거했습니다. `KakaoJson`이 serializer를 **리플렉션으로 조회**해서 R8이 참조를 볼 수 없기 때문입니다.

`KakaoSdk.init`이 등록한 `AppLifecycleObserver`가 포그라운드 진입 시 저장된 토큰을 역직렬화하면서 `SerializationException`이 발생 → 첫 화면 직후 종료.

```proguard
# android/app/proguard-rules.pro
-keep class com.kakao.sdk.**.model.* { <fields>; }
```

수정 전 `mapping.txt`에 `OAuthToken$$serializer`가 아예 없었고(제거됨), 수정 후 `$$serializer` **43개가 모두 유지**되는 것을 release 빌드로 확인했습니다. Kakao SDK 2.23.0의 `@Serializable` 클래스는 전부 `*.model` 패키지(`auth`/`common`/`share`/`template`/`user`)에 있어 이 한 줄로 빠짐없이 덮입니다.

### 2. 알림 아이콘 리소스 순환 참조 (#362)

`mipmap-anydpi-v26/ic_launcher_foreground.xml`이 **같은 이름의 리소스**를 `inset`으로 감싸고 있었습니다. API 26+에서 `@mipmap/ic_launcher_foreground`를 해석하면 `anydpi-v26`이 다시 선택되어 자기 자신을 가리키는 순환이 됩니다.

```xml
<!-- 제거된 파일 -->
<inset android:drawable="@mipmap/ic_launcher_foreground"
       android:inset="16.7%" />   <!-- ← 자기 자신 -->
```

이 XML이 같은 이름의 density PNG를 가려 리소스를 어떤 경로로도 로드할 수 없게 만들었고, manifest의 `default_notification_icon`이 이 리소스를 가리키므로 SystemUI가 아이콘 생성에 실패해 **알림을 게시 직후 제거**했습니다. 런처 아이콘이 기본 안드로이드 아이콘으로 나오던 것도 같은 원인입니다.

```
E/Icon    : Resources$NotFoundException: Drawable com.finders:mipmap/ic_launcher_foreground
W/NotifInflater: InflationException: Couldn't create icon StatusBarIcon(...)
I/NotificationListener: received notification removed event - com.finders
```

### 3. `google-services.json` 추적 재개 (#361)

#352에서 `.gitignore`에 추가되며 git에서 빠졌는데, 이 파일이 없으면 `app/build.gradle`의 try/catch가 조용히 삼켜 **google-services 플러그인이 미적용된 APK**가 나옵니다. 다른 머신·CI 빌드에서 Firebase 리소스 없이 푸시가 에러 없이 죽습니다.

API 키는 패키지명 + SHA-1로 제한되어 비밀정보가 아니며, iOS의 `GoogleService-Info.plist`는 이미 커밋되어 있어 비대칭이었습니다.

<br>

## 📌 PR 설명

### 이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] Kakao SDK 모델 keep 룰 추가 — release 빌드 첫 화면 크래시 해결 (#361)
- [x] 알림 아이콘 순환 참조 XML 2개 제거 — FCM 알림 표시 정상화 (#362)
- [x] `google-services.json` 을 `.gitignore` 에서 제외하고 커밋 (#361)
- [x] release 빌드로 `$$serializer` 43개 유지 검증 (`mapping.txt`)
- [x] 에뮬레이터(Pixel 9 Pro / API 36 / google_apis)에서 전 구간 실측 — 토큰 등록 → 관리자 발송 → 알림 표시 → 딥링크 이동

<br>

## 📷 스크린샷

UI 변경 없음. (알림 표시 동작은 아래 검증 결과 참고)

| 단계 | 결과 |
| --- | --- |
| 기기 토큰 서버 등록 | `NOTIFICATION_201`, `device_token` 1행 |
| 관리자 발송 → FCM | `successCount: 1` / `failureCount: 0` |
| 기기 알림 표시 | 헤즈업 배너 + 알림 트레이 |
| 탭 → 딥링크 이동 | `PHOTO_FEED` → `/photoFeed` |

<br>

## 💬 참고

- **후속 필요 (별도 이슈)**: 상태바 알림 아이콘이 빈 사각형으로 표시됩니다. Android는 상태바 아이콘의 알파 채널만 써서 실루엣으로 그리는데 현재 지정된 리소스가 단색 알파 아이콘이 아니기 때문입니다. `ic_stat_*` 전용 drawable을 만들고 manifest를 그쪽으로 돌려야 합니다. 제거한 XML의 원래 의도(적응형 아이콘 여백)도 순환 없이 다시 잡아야 합니다.
- **iOS 미검증**: 본 PR 변경사항은 Android 전용입니다. iOS는 알림 아이콘 리소스를 런타임에 해석하는 경로가 없어 #362의 영향을 받지 않습니다. iOS 푸시 수신은 별도 확인 중입니다.
- 서버 측 댓글·좋아요 자동 발송은 BE #730에서 구현·배포 완료되어 FE 추가 작업은 없습니다.
